### PR TITLE
docs: fix 13 broken internal links in tutorial pages

### DIFF
--- a/contributing/vision/README.md
+++ b/contributing/vision/README.md
@@ -44,5 +44,5 @@ Just as HyperCard unleashed a wave of creativity by making software development 
 ### Where to go next
 
 * Start building: [Quick Start Guide](../../getting-started/)
-* Understand the foundation: [Workspace DNA](/broken/pages/hwPV9h9VoROuoCBavjVo)
+* Understand the foundation: [Workspace DNA](../../genesis-living-system-builder/genesis/workspace-dna.md)
 * Go deeper: [Genesis Overview](../../genesis-living-system-builder/genesis/)

--- a/genesis-living-system-builder/ai-features/README.md
+++ b/genesis-living-system-builder/ai-features/README.md
@@ -10,7 +10,7 @@
 
 Living Intelligence is the agent layer in Taskade. It’s how your workspace can **reason**, **draft**, **classify**, and **take action** using context from your projects.
 
-Canonical foundation: [Workspace DNA](/broken/pages/hwPV9h9VoROuoCBavjVo).
+Canonical foundation: [Workspace DNA](../../genesis-living-system-builder/genesis/workspace-dna.md).
 
 ### What you use it for
 
@@ -33,7 +33,7 @@ Most “smartness” comes from the knowledge you give agents. That includes pro
 
 Start here:
 
-* [Workspace DNA](/broken/pages/hwPV9h9VoROuoCBavjVo)
+* [Workspace DNA](../../genesis-living-system-builder/genesis/workspace-dna.md)
 * [Agent Knowledge & Memory](https://help.taskade.com/en/articles/9495190-agent-knowledge-memory)
 
 #### Tools (what agents can do)

--- a/genesis-living-system-builder/automation/README.md
+++ b/genesis-living-system-builder/automation/README.md
@@ -10,7 +10,7 @@
 
 Living Motion is Taskade’s automation layer. It’s how your workspace can **react**, **decide**, and **execute** when something happens.
 
-Canonical foundation: [Workspace DNA](/broken/pages/hwPV9h9VoROuoCBavjVo).
+Canonical foundation: [Workspace DNA](../../genesis-living-system-builder/genesis/workspace-dna.md).
 
 ### What you use it for
 

--- a/genesis-living-system-builder/automation/comprehensive-integration-guide.md
+++ b/genesis-living-system-builder/automation/comprehensive-integration-guide.md
@@ -10,7 +10,7 @@
 
 Integrations connect Taskade to the tools you already use. They run through Automations using **triggers** (events) and **actions** (what happens next).
 
-If you want the bigger model, start with [Workspace DNA](/broken/pages/hwPV9h9VoROuoCBavjVo).
+If you want the bigger model, start with [Workspace DNA](../../genesis-living-system-builder/genesis/workspace-dna.md).
 
 ### What you can do
 

--- a/genesis-living-system-builder/genesis/README.md
+++ b/genesis-living-system-builder/genesis/README.md
@@ -45,7 +45,7 @@ This is what agents read and automations update.
 
 Start here:
 
-* [Workspace DNA](/broken/pages/hwPV9h9VoROuoCBavjVo)
+* [Workspace DNA](../../genesis-living-system-builder/genesis/workspace-dna.md)
 * [Project Views Mastery](../workspaces/project-views.md)
 
 #### 2) Living Intelligence (agents)

--- a/genesis-living-system-builder/genesis/examples-and-templates.md
+++ b/genesis-living-system-builder/genesis/examples-and-templates.md
@@ -114,7 +114,7 @@ Taskade features hundreds of project frameworks you can use to kickstart all kin
 
 Want the deeper “why templates become apps” explanation?
 
-Start with [Workspace DNA](/broken/pages/hwPV9h9VoROuoCBavjVo).
+Start with [Workspace DNA](../../genesis-living-system-builder/genesis/workspace-dna.md).
 
 ### **📊 App Categories & Business Impact**
 

--- a/genesis-living-system-builder/genesis/getting-started.md
+++ b/genesis-living-system-builder/genesis/getting-started.md
@@ -8,7 +8,7 @@
 
 Genesis turns a single prompt into a working app.\nIt creates the UI and connects it to your workspace.\nYou iterate by describing changes in plain English.
 
-Want the deeper “why it works” model?\nStart with [Workspace DNA](/broken/pages/hwPV9h9VoROuoCBavjVo).
+Want the deeper “why it works” model?\nStart with [Workspace DNA](../../genesis-living-system-builder/genesis/workspace-dna.md).
 
 ## Before You Start
 
@@ -58,7 +58,7 @@ Start by thinking about something in your business that could work better. Commo
 ***
 
 {% hint style="info" %}
-Skip the theory.\nFollow the steps below.\nIf you want the underlying model, read [Workspace DNA](/broken/pages/hwPV9h9VoROuoCBavjVo).
+Skip the theory.\nFollow the steps below.\nIf you want the underlying model, read [Workspace DNA](../../genesis-living-system-builder/genesis/workspace-dna.md).
 {% endhint %}
 
 ## Step 2: Craft Your App Description (2 minutes)

--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -105,7 +105,7 @@ When [TRIGGER EVENT], automatically [AUTOMATED ACTION].
 
 ## What to Do Next
 
-* Understand the model: [Workspace DNA](/broken/pages/hwPV9h9VoROuoCBavjVo)
+* Understand the model: [Workspace DNA](../genesis-living-system-builder/genesis/workspace-dna.md)
 * Copy templates: [Living System Examples & Templates](../genesis-living-system-builder/genesis/examples-and-templates.md)
 * Build better prompts: [Living System Best Practices](../genesis-living-system-builder/community-and-sharing/best-practices.md)
 * Add agents: [AI Agents Getting Started](../genesis-living-system-builder/ai-features/ai-agents-getting-started.md)

--- a/help-center/README.md
+++ b/help-center/README.md
@@ -22,14 +22,14 @@ Find answers fast. Pick the topic that matches what you need.
 ### Getting Started
 
 * [Quick Start Guide](../getting-started/) — sign up, create your first app, share it
-* [Workspace DNA](/broken/pages/hwPV9h9VoROuoCBavjVo) — understand how Memory, Intelligence, and Execution work together
+* [Workspace DNA](../genesis-living-system-builder/genesis/workspace-dna.md) — understand how Memory, Intelligence, and Execution work together
 
 ### Genesis (App Builder)
 
 * [What Genesis Can Build](../genesis-living-system-builder/genesis/) — dashboards, portals, tools, websites
 * [Your First App](../genesis-living-system-builder/genesis/getting-started.md) — step-by-step in 5 minutes
 * [Examples & Templates](../genesis-living-system-builder/genesis/examples-and-templates.md) — copy proven prompts
-* [MCP Connectors](/broken/pages/edGXixHEoPgFP9ulVcLu) — connect to external services
+* [MCP Connectors](../genesis-living-system-builder/genesis/mcp-connectors.md) — connect to external services
 * [Custom Domains](../genesis-living-system-builder/space-apps-guide/custom-domains.md) — brand your published apps
 * [Best Practices](../genesis-living-system-builder/community-and-sharing/best-practices.md) — build better apps
 
@@ -38,7 +38,7 @@ Find answers fast. Pick the topic that matches what you need.
 * [AI Agents Getting Started](../genesis-living-system-builder/ai-features/ai-agents-getting-started.md) — create your first agent
 * [Agent Tools Reference](../genesis-living-system-builder/ai-features/agent-tools.md) — Slack, Gmail, Sheets, and 20+ more
 * [Agent Knowledge & Memory](../genesis-living-system-builder/ai-features/agent-knowledge.md) — train agents with your data
-* [AI Agent Teams](/broken/pages/QqDbWvprLGUIBefBFe6C) — multi-agent collaboration
+* [AI Agent Teams](../genesis-living-system-builder/ai-features/agent-teams.md) — multi-agent collaboration
 
 ### Automations
 


### PR DESCRIPTION
## Fix broken internal links in tutorial pages

Repairs **13 dead `/broken/pages/<id>` GitBook links** across **9 tutorial pages**, pointing each at the real relative target. These were orphaned references left behind when pages were reorganized; they currently render as "Broken link" on docs.taskade.com.

### What changed

| Source page | Links fixed | Target |
|---|---:|---|
| `help-center/README.md` | 3 | `workspace-dna.md`, `mcp-connectors.md`, `agent-teams.md` |
| `genesis/getting-started.md` | 2 | `workspace-dna.md` |
| `ai-features/README.md` | 2 | `workspace-dna.md` |
| `getting-started/README.md` | 1 | `workspace-dna.md` |
| `contributing/vision/README.md` | 1 | `workspace-dna.md` |
| `automation/README.md` | 1 | `workspace-dna.md` |
| `automation/comprehensive-integration-guide.md` | 1 | `workspace-dna.md` |
| `genesis/README.md` | 1 | `workspace-dna.md` |
| `genesis/examples-and-templates.md` | 1 | `workspace-dna.md` |

### Target mapping

| Broken id | Real page |
|---|---|
| `/broken/pages/hwPV9h9VoROuoCBavjVo` | `genesis-living-system-builder/genesis/workspace-dna.md` |
| `/broken/pages/edGXixHEoPgFP9ulVcLu` | `genesis-living-system-builder/genesis/mcp-connectors.md` |
| `/broken/pages/QqDbWvprLGUIBefBFe6C` | `genesis-living-system-builder/ai-features/agent-teams.md` |

### Verification

- ✅ All 3 target pages exist on `origin/main`
- ✅ Every repaired relative path resolves from its source file's directory
- ✅ No `/broken/pages/` references remain in these files
- ✅ Pure link repair — **no prose changes**, 13 insertions / 13 deletions

### Merge notes

- Branched fresh off `origin/main`; **disjoint** from the developer-platform PR (no file overlap) — merge in any order.
