### PR TITLE
docs: cross-reference repair + live render fixes + developer cross-link enrichment

### DIFF
--- a/account-management/credits-and-billing.md
+++ b/account-management/credits-and-billing.md
@@ -139,6 +139,10 @@ Taskade never silently fails an AI request due to insufficient credits.
 Public agent visitors never see internal billing errors. If your app's agent runs out of credits, external users see a neutral error message, not billing details.
 {% endhint %}
 
+{% hint style="info" %}
+Building against the API? See the [REST API guide](../apis-living-system-development/comprehensive-api-guide/README.md) for rate limits and error-handling conventions when requests fail.
+{% endhint %}
+
 ***
 
 ## FAQ

--- a/genesis-living-system-builder/ai-features/agent-tools.md
+++ b/genesis-living-system-builder/ai-features/agent-tools.md
@@ -141,6 +141,8 @@ Connect your agents to external platforms for real-world actions:
 
 > **104 automation actions** and **40+ external service integrations** are available. Agents can use any automation flow as a custom tool. See [Automations](../automation/README.md) for the full integration list.
 
+> **For developers:** The **HTTP/Webhooks** custom tool lets agents call any external API. See [Webhooks](../../apis-living-system-development/webhooks.md) for programmatic event delivery and payload details.
+
 ---
 
 ## Build Custom Agent Tools

--- a/genesis-living-system-builder/ai-features/ai-agents-getting-started.md
+++ b/genesis-living-system-builder/ai-features/ai-agents-getting-started.md
@@ -616,7 +616,7 @@ Transform your AI agents into complete business applications. One prompt = one a
 
 Make your agents work automatically:
 
-* [**Automation Getting Started →**](../../features/ai-features/automation-getting-started.md) - Put agents on autopilot
+* [**Automation Getting Started →**](../automation/README.md) - Put agents on autopilot
 * [**Integration Guide →**](../automation/integrations.md) - Connect to 100+ services
 
 #### **Build Agent-Centric Automations**
@@ -659,7 +659,7 @@ Create automation workflows with your AI agents at the center:
 Supercharge your agents with better knowledge:
 
 * [**Knowledge Management Guide →**](../workspaces/knowledge-management.md) - Organize information effectively
-* [**Project Views →**](../../features/project-views-mastery.md) - Structure data for AI understanding
+* [**Project Views →**](../workspaces/project-views.md) - Structure data for AI understanding
 
 ## 🎯 Advanced Agent Features
 

--- a/genesis-living-system-builder/ai-features/image-generation.md
+++ b/genesis-living-system-builder/ai-features/image-generation.md
@@ -130,6 +130,6 @@ Copy these prompts directly — swap in your specific details.
 | Guide | What You'll Learn |
 |---|---|
 | [Adding Genesis Context](../genesis/adding-context.md) | Upload brand assets and design references |
-| [Guide to App Styles](../space-apps-guide/app-styles.md) | Visual style families to pair with your images |
+| [Guide to App Styles](../space-apps-guide/advanced-features.md) | Visual style families to pair with your images |
 | [Publish and Clone Your Apps](../community-and-sharing/publish-and-clone.md) | Deploy your app with custom images |
 | [Media AI Chat](./media-ai-chat.md) | Chat with media files and images using AI |

--- a/genesis-living-system-builder/ai-features/image-generation.md
+++ b/genesis-living-system-builder/ai-features/image-generation.md
@@ -130,6 +130,6 @@ Copy these prompts directly — swap in your specific details.
 | Guide | What You'll Learn |
 |---|---|
 | [Adding Genesis Context](../genesis/adding-context.md) | Upload brand assets and design references |
-| [Guide to App Styles](../space-apps-guide/advanced-features.md) | Visual style families to pair with your images |
+| [Advanced Features](../space-apps-guide/advanced-features.md) | Customize app branding and appearance |
 | [Publish and Clone Your Apps](../community-and-sharing/publish-and-clone.md) | Deploy your app with custom images |
 | [Media AI Chat](./media-ai-chat.md) | Chat with media files and images using AI |

--- a/genesis-living-system-builder/ai-features/multi-agents.md
+++ b/genesis-living-system-builder/ai-features/multi-agents.md
@@ -183,3 +183,4 @@ Multi-agent chats support both AI agents and human team members in the same conv
 | [Agent Knowledge & Memory](./agent-knowledge.md) | Train agents with domain knowledge |
 | [Tools for AI Agents](./agent-tools.md) | Add capabilities to each agent |
 | [Automations](../automation/README.md) | Connect agents to automated workflows |
+| [Autonomous Agents (API)](../../apis-living-system-development/autonomous-agents.md) | Orchestrate multi-agent systems programmatically |

--- a/genesis-living-system-builder/automation/actions.md
+++ b/genesis-living-system-builder/automation/actions.md
@@ -1331,5 +1331,5 @@ Automations now handle a wide range of file types:
 
 ***
 
-→ **Next:** [**Browse Triggers Reference**](../../automation/triggers.md)\
+→ **Next:** [**Browse Triggers Reference**](./advanced-actions.md)\
 → **See Also:** [**Automation Recipes**](recipes.md)

--- a/genesis-living-system-builder/automation/actions.md
+++ b/genesis-living-system-builder/automation/actions.md
@@ -1331,5 +1331,5 @@ Automations now handle a wide range of file types:
 
 ***
 
-→ **Next:** [**Browse Triggers Reference**](./advanced-actions.md)\
+→ **Next:** [**Advanced Automation Actions**](./advanced-actions.md)\
 → **See Also:** [**Automation Recipes**](recipes.md)

--- a/genesis-living-system-builder/automation/advanced-actions.md
+++ b/genesis-living-system-builder/automation/advanced-actions.md
@@ -171,7 +171,7 @@ Automatically retry failed operations with exponential backoff:
 ```
 
 {% hint style="info" %}
-**Building your own webhook receiver?** See the developer [Webhooks reference](../../apis-living-system-development/webhooks.md) for payload formats, signature verification, and event types.
+**Building your own webhook receiver?** See the developer [Webhooks reference](../../apis-living-system-development/webhooks.md) for payload formats and event types.
 {% endhint %}
 
 ### **Message Types & Templates**

--- a/genesis-living-system-builder/automation/advanced-actions.md
+++ b/genesis-living-system-builder/automation/advanced-actions.md
@@ -170,6 +170,10 @@ Automatically retry failed operations with exponential backoff:
 }
 ```
 
+{% hint style="info" %}
+**Building your own webhook receiver?** See the developer [Webhooks reference](../../apis-living-system-development/webhooks.md) for payload formats, signature verification, and event types.
+{% endhint %}
+
 ### **Message Types & Templates**
 
 #### **Text Messages**

--- a/genesis-living-system-builder/automation/ai-forms.md
+++ b/genesis-living-system-builder/automation/ai-forms.md
@@ -602,7 +602,7 @@ Results:
 
 ### **Getting Help**
 
-* **Documentation**: [Complete AI Forms API Reference](../../api/forms/)
+* **Documentation**: [Taskade Developer API](../../apis-living-system-development/developer-home.md)
 * **Community**: [AI Forms Discussion Forum](https://community.taskade.com/ai-forms)
 * **Support**: Contact support for advanced AI configuration assistance
 * **Templates**: Browse pre-built AI form templates in your workspace

--- a/genesis-living-system-builder/automation/integrations.md
+++ b/genesis-living-system-builder/automation/integrations.md
@@ -91,6 +91,8 @@ Taskade connects to **100+ tools and services** across communication, productivi
 | **Database** | Record created, updated | Insert record, update data, run query | Connection String |
 | **FTP/SFTP** | File uploaded, modified | Upload file, download, sync directory | Credentials |
 
+> **Related developer docs:** Build custom integrations programmatically with the [Developer Hub](../../apis-living-system-development/developer-home.md) and [Webhooks](../../apis-living-system-development/webhooks.md).
+
 ## Integration Setup
 
 ### 1. **Authentication**

--- a/genesis-living-system-builder/automation/recipes.md
+++ b/genesis-living-system-builder/automation/recipes.md
@@ -217,35 +217,44 @@ Schedule and automate social media posts using due dates and custom fields. Perf
 
 **Setup Instructions:**
 
-\{% stepper %\} \{% step %\}
+{% stepper %}
+
+{% step %}
 
 ### Create Content Calendar Project
 
-Set up a Taskade project using Table view to organize your social media content \{% endstep %\}
+Set up a Taskade project using Table view to organize your social media content
+{% endstep %}
 
-\{% step %\}
+{% step %}
 
 ### Add Custom Fields
 
-Create fields for Status (dropdown: draft, scheduled, posted), Platform, and Posted\_At (date) \{% endstep %\}
+Create fields for Status (dropdown: draft, scheduled, posted), Platform, and Posted_At (date)
+{% endstep %}
 
-\{% step %\}
+{% step %}
 
 ### Set Up Automation Trigger
 
-Create a "Task Due" trigger that fires when content is scheduled to post \{% endstep %\}
+Create a "Task Due" trigger that fires when content is scheduled to post
+{% endstep %}
 
-\{% step %\}
+{% step %}
 
 ### Configure Social Media Actions
 
-Add conditional actions for each platform (Twitter, LinkedIn, Facebook) based on custom field values \{% endstep %\}
+Add conditional actions for each platform (Twitter, LinkedIn, Facebook) based on custom field values
+{% endstep %}
 
-\{% step %\}
+{% step %}
 
 ### Add Status Updates
 
-Include actions to update the task status and posting timestamp after successful publication \{% endstep %\} \{% endstepper %\}
+Include actions to update the task status and posting timestamp after successful publication
+{% endstep %}
+
+{% endstepper %}
 
 **Platform-Specific Configuration:**
 
@@ -258,7 +267,9 @@ Include actions to update the task status and posting timestamp after successful
 
 **Advanced Features:**
 
-\{% hint style="info" %\} **Multi-Platform Posting**: Set up conditional logic to post the same content across multiple platforms simultaneously. \{% endhint %\}
+{% hint style="info" %}
+**Multi-Platform Posting**: Set up conditional logic to post the same content across multiple platforms simultaneously.
+{% endhint %}
 
 **Content Personalization:**
 

--- a/genesis-living-system-builder/community-and-sharing/publish-and-clone.md
+++ b/genesis-living-system-builder/community-and-sharing/publish-and-clone.md
@@ -23,7 +23,7 @@
 
 Once you've built an app with Genesis, you can share it with the world in multiple ways — from private team tools to public community templates. This guide covers every publishing, sharing, and distribution option available.
 
-> **Haven't built an app yet?** Start with [Create Your First App](../genesis/create-your-first-app.md).
+> **Haven't built an app yet?** Start with [Create Your First App](../genesis/getting-started.md).
 
 ---
 
@@ -205,5 +205,8 @@ Connect your own domain to any published Genesis app:
 |---|---|
 | [Genesis Version History](../genesis/version-history.md) | Track changes and restore previous versions |
 | [App Analytics](../genesis/app-analytics.md) | Monitor visitor data and optimize your app |
-| [Create Your First App](../genesis/create-your-first-app.md) | Build something to publish |
+| [Create Your First App](../genesis/getting-started.md) | Build something to publish |
 | [Taskade AI Credits](https://help.taskade.com/en/articles/taskade-ai-credits) | Understand credit costs for app operations |
+| [Sharing Best Practices](best-practices.md) | Tips for collaborating and distributing apps |
+| [Sharing FAQ](faq.md) | Common questions about publishing and access |
+| [Developer Platform](../../apis-living-system-development/developer-home.md) | Publish and manage apps programmatically via the API |

--- a/genesis-living-system-builder/genesis/adding-context.md
+++ b/genesis-living-system-builder/genesis/adding-context.md
@@ -57,6 +57,10 @@ Genesis works with a wide range of file types to understand your requirements:
 | **Requirements docs** | Feature specs, acceptance criteria, use cases | Implements exact feature requirements |
 | **API/Tech docs** | API specs, integration guides, config files | Connects to your existing systems |
 
+{% hint style="info" %}
+Connecting Genesis to Taskade programmatically? See the [Public API reference](../../apis-living-system-development/comprehensive-api-guide/README.md).
+{% endhint %}
+
 ### Supported Upload Formats
 
 | Category | Formats |
@@ -147,6 +151,6 @@ Every file you upload becomes part of your workspace's living memory:
 | Guide | What You'll Learn |
 |---|---|
 | [Image Generation](../ai-features/image-generation.md) | Generate custom images for your apps |
-| [Guide to App Styles](../space-apps-guide/app-styles.md) | Use your brand context to apply specific visual styles |
+| [Guide to App Styles](../space-apps-guide/advanced-features.md) | Use your brand context to apply specific visual styles |
 | [Agent Knowledge & Memory](../ai-features/agent-knowledge.md) | Train AI agents on your uploaded files |
 | [Projects & Databases](../workspaces/projects-databases.md) | How uploaded data becomes structured databases |

--- a/genesis-living-system-builder/genesis/adding-context.md
+++ b/genesis-living-system-builder/genesis/adding-context.md
@@ -151,6 +151,6 @@ Every file you upload becomes part of your workspace's living memory:
 | Guide | What You'll Learn |
 |---|---|
 | [Image Generation](../ai-features/image-generation.md) | Generate custom images for your apps |
-| [Guide to App Styles](../space-apps-guide/advanced-features.md) | Use your brand context to apply specific visual styles |
+| [Advanced Features](../space-apps-guide/advanced-features.md) | Use your brand context to customize app appearance |
 | [Agent Knowledge & Memory](../ai-features/agent-knowledge.md) | Train AI agents on your uploaded files |
 | [Projects & Databases](../workspaces/projects-databases.md) | How uploaded data becomes structured databases |

--- a/genesis-living-system-builder/genesis/github-import-export.md
+++ b/genesis-living-system-builder/genesis/github-import-export.md
@@ -143,6 +143,10 @@ Re-exporting the same app either updates the open PR or opens a new one, dependi
 [bundles.md](../../apis-living-system-development/bundles.md)
 {% endcontent-ref %}
 
+{% content-ref url="../../apis-living-system-development/developer-home.md" %}
+[developer-home.md](../../apis-living-system-development/developer-home.md)
+{% endcontent-ref %}
+
 {% content-ref url="../community-and-sharing/genesis-auth.md" %}
 [genesis-auth.md](../community-and-sharing/genesis-auth.md)
 {% endcontent-ref %}

--- a/genesis-living-system-builder/genesis/how-genesis-works.md
+++ b/genesis-living-system-builder/genesis/how-genesis-works.md
@@ -345,4 +345,5 @@ You now understand the DNA of your workspace. Choose your path:
 |---|---|
 | [Adding Genesis Context](./adding-context.md) | Upload files and data to enrich app intelligence |
 | [Publish and Clone Your Apps](../community-and-sharing/publish-and-clone.md) | Deploy, share, and distribute your apps |
-| [Taskade AI Credits](../../ai-credits.md) | Understand credits, models, and usage |
+| [Taskade AI Credits](../../account-management/credits-and-billing.md) | Understand credits, models, and usage |
+| [Build on Taskade (Developer Hub)](../../apis-living-system-development/developer-home.md) | APIs, SDKs, and MCP for programmatic access |

--- a/genesis-living-system-builder/genesis/prompt-guide.md
+++ b/genesis-living-system-builder/genesis/prompt-guide.md
@@ -143,7 +143,7 @@ Genesis supports 100+ integrations. Mention your tools and Genesis creates the a
 | **Bold & energetic** | "Bold orange and black colors. Strong typography and high-contrast buttons that motivate action." |
 | **Dark & premium** | "Dark theme with neon accents, like a high-tech dashboard. Charcoal backgrounds with electric blue highlights." |
 
-> **Deep dive:** [Guide to App Styles](../space-apps-guide/app-styles.md) covers minimalist, glassmorphism, neumorphism, material design, and more.
+> **Deep dive:** [Guide to App Styles](../space-apps-guide/advanced-features.md) covers minimalist, glassmorphism, neumorphism, material design, and more.
 
 ---
 
@@ -245,6 +245,6 @@ Use this cheat sheet when building:
 | Guide | What You'll Learn |
 |---|---|
 | [App Starter Prompts](../space-apps-guide/genesis-prompt-library.md) | Copy-ready prompts for common app types |
-| [Guide to App Styles](../space-apps-guide/app-styles.md) | Visual style families with practical prompts |
+| [Guide to App Styles](../space-apps-guide/advanced-features.md) | Visual style families with practical prompts |
 | [Adding Genesis Context](./adding-context.md) | Upload reference files for richer apps |
-| [Prompt Templates Library](./templates.md) | Browse the full prompt template collection |
+| [Prompt Templates Library](./examples-and-templates.md) | Browse the full prompt template collection |

--- a/genesis-living-system-builder/genesis/prompt-guide.md
+++ b/genesis-living-system-builder/genesis/prompt-guide.md
@@ -143,7 +143,7 @@ Genesis supports 100+ integrations. Mention your tools and Genesis creates the a
 | **Bold & energetic** | "Bold orange and black colors. Strong typography and high-contrast buttons that motivate action." |
 | **Dark & premium** | "Dark theme with neon accents, like a high-tech dashboard. Charcoal backgrounds with electric blue highlights." |
 
-> **Deep dive:** [Guide to App Styles](../space-apps-guide/advanced-features.md) covers minimalist, glassmorphism, neumorphism, material design, and more.
+> **Deep dive:** [Advanced Features](../space-apps-guide/advanced-features.md) covers customizing your app's branding, appearance, and behavior.
 
 ---
 
@@ -245,6 +245,6 @@ Use this cheat sheet when building:
 | Guide | What You'll Learn |
 |---|---|
 | [App Starter Prompts](../space-apps-guide/genesis-prompt-library.md) | Copy-ready prompts for common app types |
-| [Guide to App Styles](../space-apps-guide/advanced-features.md) | Visual style families with practical prompts |
+| [Advanced Features](../space-apps-guide/advanced-features.md) | Customize app branding, appearance, and behavior |
 | [Adding Genesis Context](./adding-context.md) | Upload reference files for richer apps |
 | [Prompt Templates Library](./examples-and-templates.md) | Browse the full prompt template collection |

--- a/genesis-living-system-builder/space-apps-guide/README.md
+++ b/genesis-living-system-builder/space-apps-guide/README.md
@@ -449,8 +449,8 @@ Ensure your apps are accessible to all users:
 
 ### Documentation Links
 
-* [**Genesis API Reference**](../../api/genesis/) - Complete API documentation
-* [**Space Apps API**](../../api/genesis/#space-apps) - Specific Space Apps endpoints
+* [**Genesis API Reference**](../../apis-living-system-development/developer-home.md) - Complete API documentation
+* [**Space Apps API**](../../apis-living-system-development/developer-home.md) - Specific Space Apps endpoints
 * [**Best Practices**](../community-and-sharing/best-practices.md) - General Genesis optimization tips
 * [**Examples Gallery**](../genesis/examples-and-templates.md) - Ready-to-use prompts
 
@@ -485,7 +485,7 @@ Space Apps represent the future of no-code application development - combining t
 ### Next Steps
 
 1. [**Create your first Space App**](https://taskade.com/genesis) in your workspace
-2. **Explore the** [**API documentation**](../../api/genesis/) for advanced integrations
+2. **Explore the** [**API documentation**](../../apis-living-system-development/developer-home.md) for advanced integrations
 3. **Join our** [**community**](https://www.taskade.com/feedback) to share your creation and get inspiration
 4. **Check out** [**advanced features**](advanced-features.md) as your app grows in complexity
 

--- a/genesis-living-system-builder/space-apps-guide/advanced-features.md
+++ b/genesis-living-system-builder/space-apps-guide/advanced-features.md
@@ -217,7 +217,11 @@ Transform your private AI agents into public resources accessible to anyone:
 
 **Agents Anywhere on the Web:**
 
-Embed your public agent using the in-product “Embed” option.\nUse it for support chat, onboarding, or interactive docs.\nIf you need setup help, start with [AI Agents Getting Started](../ai-features/ai-agents-getting-started.md).
+Embed your public agent using the in-product “Embed” option.
+
+Use it for support chat, onboarding, or interactive docs.
+
+If you need setup help, start with [AI Agents Getting Started](../ai-features/ai-agents-getting-started.md).
 
 **Embedding Use Cases:**
 
@@ -807,7 +811,11 @@ Brand your Genesis apps with professional custom domains:
 
 What you get with a custom domain:
 
-* Branded URL (e.g., `app.yourcompany.com`)\n\* Automatic SSL\n\* Fast global delivery\n\* A cleaner, professional sharing experience
+* Branded URL (e.g., `app.yourcompany.com`)
+
+* Automatic SSL
+* Fast global delivery
+* A cleaner, professional sharing experience
 
 See [Custom Domains & Branding](custom-domains.md).
 

--- a/genesis-living-system-builder/space-apps-guide/genesis-prompt-library.md
+++ b/genesis-living-system-builder/space-apps-guide/genesis-prompt-library.md
@@ -454,4 +454,4 @@ Copy these complete prompts for instant apps:
 * **Include Branding:** Add your colors, logo, and company voice
 * **Test First:** Start simple, then add complexity based on results
 
-**Need help customizing these prompts?** Visit our [Genesis Getting Started Guide](../../features/ai-features/genesis-getting-started.md) for detailed instructions!
+**Need help customizing these prompts?** Visit our [Genesis Getting Started Guide](../genesis/getting-started.md) for detailed instructions!

--- a/genesis-living-system-builder/workspaces/README.md
+++ b/genesis-living-system-builder/workspaces/README.md
@@ -920,5 +920,5 @@ Automate user lifecycle management with SCIM 2.0 support:
 
 * [Collaboration](collaboration.md) - Team communication and coordination
 * [AI Agents](../ai-features/ai-agents-getting-started.md) - Workspace-wide AI assistance
-* [Project Views](../../features/project-views-mastery.md) - Organizing and visualizing work
+* [Project Views](./project-views.md) - Organizing and visualizing work
 * [Mobile Optimization](mobile-optimization.md) - Mobile workspace management

--- a/genesis-living-system-builder/workspaces/collaboration.md
+++ b/genesis-living-system-builder/workspaces/collaboration.md
@@ -867,6 +867,6 @@ Receive intelligent responses based on the file's actual content
 **Related Features:**
 
 * [AI Agents](../ai-features/ai-agents-getting-started.md) - Collaborative AI assistants
-* [Project Views](../../features/project-views-mastery.md) - Visual collaboration tools
+* [Project Views](./project-views.md) - Visual collaboration tools
 * [Mobile Optimization](mobile-optimization.md) - Mobile collaboration features
 * [Workspaces](./) - Team organization and management

--- a/genesis-living-system-builder/workspaces/editing-formatting.md
+++ b/genesis-living-system-builder/workspaces/editing-formatting.md
@@ -172,5 +172,5 @@ Enhance tasks with additional features:
 |---|---|
 | [Markdown Support](./markdown.md) | Full Markdown syntax reference |
 | [Import](./import.md) | Import .md and PDF files as projects |
-| [Version History](./version-history.md) | Track and restore editing changes |
+| [Version History](../genesis/version-history.md) | Track and restore editing changes |
 | [Embed Taskade](./embed.md) | Embed projects on your website |

--- a/genesis-living-system-builder/workspaces/import.md
+++ b/genesis-living-system-builder/workspaces/import.md
@@ -221,3 +221,4 @@ PDFs can be processed automatically within automation flows:
 |---|---|
 | [Markdown Support](./markdown.md) | Full syntax reference and usage guide |
 | [Editing & Formatting](./editing-formatting.md) | Format tasks and projects |
+| [REST API Guide](../../apis-living-system-development/comprehensive-api-guide/README.md) | Import and create projects programmatically via the API |

--- a/genesis-living-system-builder/workspaces/knowledge-management.md
+++ b/genesis-living-system-builder/workspaces/knowledge-management.md
@@ -672,3 +672,5 @@ Sales Team Results:
 **🧠 Ready to transform your scattered information into AI-powered intelligence?** Start with organizing your most frequently needed documents, then expand to comprehensive knowledge coverage.
 
 _For advanced AI agent training techniques, see our_ [_AI Agents Guide_](../ai-features/ai-agents-getting-started.md)_. For automation of knowledge processes, check out_ [_Advanced Automation Actions_](../automation/advanced-actions.md)_._
+
+_To build programmatic knowledge workflows like the bulk upload and search examples above, see the_ [_Developer Hub_](../../apis-living-system-development/developer-home.md) _and the_ [_REST API Guide_](../../apis-living-system-development/comprehensive-api-guide/README.md)_._

--- a/genesis-living-system-builder/workspaces/project-views.md
+++ b/genesis-living-system-builder/workspaces/project-views.md
@@ -58,4 +58,6 @@ The REST and GraphQL APIs expose **data only**; view choice is a client-side con
 
 **[API Documentation →](https://www.taskade.com/api/documentation/)**
 
+**[REST API v1 Guide →](../../apis-living-system-development/comprehensive-api-guide/README.md)**
+
 ---

--- a/genesis-living-system-builder/workspaces/projects-databases.md
+++ b/genesis-living-system-builder/workspaces/projects-databases.md
@@ -37,7 +37,7 @@ Database projects are structured data containers that serve as your app's persis
 | **Views** | List, board, table, calendar, and more |
 | **Filters & sorts** | Find and organize data dynamically |
 | **Permissions** | Control who can view and edit data |
-| **API access** | Programmatic access for integrations (Business+) |
+| **API access** | Programmatic access for integrations (Business+) — see the [REST API reference](../../apis-living-system-development/comprehensive-api-guide/README.md) |
 | **Real-time sync** | Changes reflect instantly across all connected apps and agents |
 | **Revision tracking** | Every change tracked via operational transform (OT) |
 

--- a/genesis-living-system-builder/workspaces/teams.md
+++ b/genesis-living-system-builder/workspaces/teams.md
@@ -157,7 +157,7 @@ Taskade uses a **5-role, 7-tier RBAC** permission system:
 | **Automation Workflows** | Automate cross-department processes | [Automation Triggers](../automation/README.md) |
 | **Genesis Apps** | Build internal tools and dashboards for teams | [Taskade Genesis](https://help.taskade.com/en/collections/14476419-taskade-genesis) |
 | **Shared Agent Chats** | AI + human conversations together | [Custom AI Agents](https://help.taskade.com/en/collections/14476419-taskade-genesis) |
-| **Version History** | Track all changes across team projects | [Version History](./version-history.md) |
+| **Version History** | Track all changes across team projects | [Version History](../genesis/version-history.md) |
 | **Real-time Collaboration** | Multiple users editing simultaneously (OT-based) | Built-in |
 
 ---
@@ -169,4 +169,4 @@ Taskade uses a **5-role, 7-tier RBAC** permission system:
 | [Taskade Autopilot](../ai-features/autopilot.md) | Auto-generate team workspaces |
 | [Editing & Formatting](./editing-formatting.md) | Format and style team projects |
 | [Embed Taskade](./embed.md) | Share projects on your website |
-| [Version History](./version-history.md) | Track team changes |
+| [Version History](../genesis/version-history.md) | Track team changes |

--- a/help-and-support/comprehensive-troubleshooting-guide.md
+++ b/help-and-support/comprehensive-troubleshooting-guide.md
@@ -388,7 +388,7 @@ Verify your credentials for the third-party service are still valid.
 
 #### Data Transfer Issues
 
-* **API Limits**: Check if you've exceeded API rate limits for the integrated service
+* **API Limits**: Check if you've exceeded API rate limits for the integrated service — see the [REST API guide](../apis-living-system-development/comprehensive-api-guide/README.md) for rate limits and error handling
 * **Data Format**: Ensure data formats are compatible between services
 * **Field Mapping**: Verify field mapping is correctly configured
 * **Sync Frequency**: Adjust sync frequency if experiencing timeout issues

--- a/help-and-support/index/01_workspaces.md
+++ b/help-and-support/index/01_workspaces.md
@@ -218,4 +218,4 @@ But you don't need to understand the technical details—the magic happens autom
 
 _What questions do you have about workspaces? This living foundation concept can seem magical at first, but once you start using it, you'll wonder how you ever worked without it!_
 
-[← Back to Tutorial Overview](../../index.md) | [Next: Projects →](02_projects.md)
+[← Back to Tutorial Overview](README.md) | [Next: Projects →](02_projects.md)

--- a/help-and-support/index/07_api.md
+++ b/help-and-support/index/07_api.md
@@ -8,6 +8,10 @@ nav_order: 7
 
 Brilliant! You've connected your tools and built integrated workflows. Now let's **unlock unlimited possibilities** with Taskade's API—giving you programmatic access to build custom applications, advanced integrations, and automated systems that extend Taskade infinitely.
 
+{% hint style="info" %}
+For the full developer reference—authentication, endpoints, SDKs, and more—see the [Developer Home](../../apis-living-system-development/developer-home.md).
+{% endhint %}
+
 ## What Problem Does the API Solve?
 
 **Pre-built integrations have limitations:**
@@ -241,6 +245,8 @@ await api.put(`/tasks/${taskId}`, {
 ## Advanced API Techniques
 
 ### Webhooks for Real-Time Integration
+
+For full setup, event types, and signature verification, see the [Webhooks reference](../../apis-living-system-development/webhooks.md).
 
 **Get instant notifications of changes:**
 

--- a/help-and-support/index/07_api.md
+++ b/help-and-support/index/07_api.md
@@ -246,7 +246,7 @@ await api.put(`/tasks/${taskId}`, {
 
 ### Webhooks for Real-Time Integration
 
-For full setup, event types, and signature verification, see the [Webhooks reference](../../apis-living-system-development/webhooks.md).
+For full setup and event types, see the [Webhooks reference](../../apis-living-system-development/webhooks.md).
 
 **Get instant notifications of changes:**
 

--- a/help-and-support/index/08_mobile_desktop.md
+++ b/help-and-support/index/08_mobile_desktop.md
@@ -493,4 +493,4 @@ This concludes our comprehensive tutorial! You've transformed from a productivit
 
 _Where will your living workspace take you next? The possibilities are endless—start building, stay curious, and keep your workspace alive and evolving!_
 
-[← Back to Chapter 7: API](07_api.md) | [← Back to Tutorial Overview](../../index.md)
+[← Back to Chapter 7: API](07_api.md) | [← Back to Tutorial Overview](README.md)

--- a/help-center/import-and-export.md
+++ b/help-center/import-and-export.md
@@ -178,6 +178,7 @@ Need a hard copy? You can also print directly:
 
 ## Related Guides
 
-* [Getting Started with Taskade](getting-started/)
-* [AI Agents Getting Started](ai-features/ai-agents-getting-started.md)
-* [Features Overview](features/)
+* [Getting Started with Taskade](../getting-started/)
+* [AI Agents Getting Started](../genesis-living-system-builder/ai-features/ai-agents-getting-started.md)
+* [Features Overview](../genesis-living-system-builder/genesis/README.md)
+* [Developer Hub](../apis-living-system-development/developer-home.md) — for programmatic and bulk migration via the API

--- a/help-center/mobile-app.md
+++ b/help-center/mobile-app.md
@@ -181,7 +181,7 @@ Need to work without an internet connection? Taskade has you covered.
 
 ## Related Guides
 
-* [Getting Started with Taskade](getting-started/)
-* [AI Agents Getting Started](ai-features/ai-agents-getting-started.md)
+* [Getting Started with Taskade](../getting-started/)
+* [AI Agents Getting Started](../genesis-living-system-builder/ai-features/ai-agents-getting-started.md)
 * [Import & Export](import-and-export.md)
-* [Features Overview](features/)
+* [Features Overview](../genesis-living-system-builder/genesis/README.md)


### PR DESCRIPTION
## Cross-reference repair + live render fixes + developer cross-link enrichment

A full cross-reference and visual-polish pass over the docs, **verified against the live docs.taskade.com site** with a multi-agent render audit (curl-based; the site is server-rendered). Repairs every broken live cross-reference, fixes render leakage that showed as raw text, and connects product/help pages to the developer hub.

### How this was scoped

- Audited all **962 `.md` files**; excluded `archive/` (738 files, not in nav) → focused on the **188 live pages** reachable from `SUMMARY.md`.
- Fetched live pages across every section with 5 audit agents — which surfaced a defect class **static analysis alone misses** (see below).
- **Disjoint from #56 / #57** — no file or `SUMMARY.md` overlap, so all three PRs merge independently.

### 1 · Cross-reference repairs (broken links → real targets)

| Broken target | Repointed to | Files |
|---|---|---|
| `space-apps-guide/app-styles.md` (missing) | `space-apps-guide/advanced-features.md` | 3 |
| `./version-history.md` (wrong dir) | `../genesis/version-history.md` | 2 |
| `../genesis/create-your-first-app.md` | `../genesis/getting-started.md` | 1 |
| `../../ai-credits.md` | `account-management/credits-and-billing.md` | 1 |
| `./templates.md` | `./examples-and-templates.md` | 1 |
| legacy `../../api/genesis/`, `../../api/forms/` | `apis-living-system-development/developer-home.md` | 2 |
| `../../index.md` (tutorial nav) | same-dir `README.md` | 2 |

### 2 · GitHub-blob fallback fixes (the audit's key catch)

GitBook renders a relative link to **any file not in `SUMMARY.md`** (missing *or* orphaned) as an external `https://github.com/taskade/docs/blob/main/…` URL — silently **ejecting readers out of the docs to raw markdown**. A file-existence check can't catch these; the live fetch did.

| Page | Was (ejected to GitHub) | Now |
|---|---|---|
| `workspaces/README.md`, `workspaces/collaboration.md` | `../../features/project-views-mastery.md` | `./project-views.md` |
| `ai-features/ai-agents-getting-started.md` | `../../features/…automation-getting-started.md`, `…project-views-mastery.md` | `../automation/README.md`, `../workspaces/project-views.md` |
| `automation/actions.md` | `../../automation/triggers.md` | `./advanced-actions.md` |
| `space-apps-guide/genesis-prompt-library.md` | `../../features/…genesis-getting-started.md` | `../genesis/getting-started.md` |
| `help-center/import-and-export.md`, `mobile-app.md` | orphan `getting-started/`, `ai-features/…`, `features/` | real `../getting-started/`, `../genesis-living-system-builder/…` |

### 3 · Render leakage fixes (rendered as raw text on live)

| File | Defect | Fix |
|---|---|---|
| `automation/recipes.md` | Entire stepper + a hint were **backslash-escaped** (`\{% step %\}`) → rendered as literal `{% step %}` text | Reconstructed as valid GitBook `{% stepper %}` / `{% hint %}` blocks |
| `space-apps-guide/advanced-features.md` | Literal prose `\n` showed as visible "\n" and collapsed a bullet list | Converted to real line breaks / bullets |

*(Systemic scan confirmed `recipes.md` was the only file with escaped tags; `markdown.md`'s `\n` are intentional syntax examples inside code spans and were left alone.)*

### 4 · Enrichment — connect product docs → developer hub (16 pages)

One conservative, additive developer cross-link added to each page **where it already mentions API / programmatic / integration access** — matching existing table/hint/content-ref style. Targets: `developer-home.md`, `comprehensive-api-guide/README.md` (REST v1), `webhooks.md`, `autonomous-agents.md`.

Examples: Genesis "Go Deeper" table → Developer Hub · Workspaces "API access" → REST API v1 · Agent Tools (HTTP/Webhooks) → Webhooks · API tutorial chapter → Developer Home + Webhooks · Credits & Billing → API rate limits.

### Verification

- ✅ **0** live broken links · **0** github-blob fallbacks (re-checked after enrichment)
- ✅ All 16 new enrichment links resolve to real files
- ✅ Balanced GitBook syntax across all 32 files (0 escaped tags remain)
- ✅ No secrets / placeholders / `/broken/pages/` markers
- ✅ Branched fresh off `origin/main`; **0 overlap** with #56/#57

**32 files changed, +100 / −44.**
