### PR TITLE
docs: fix live render leakage — recipes fence trap + getting-started newlines

### DIFF
--- a/genesis-living-system-builder/automation/recipes.md
+++ b/genesis-living-system-builder/automation/recipes.md
@@ -137,8 +137,6 @@ Start with one article, review the output, and adjust the agent prompts or autom
 * **Multi-platform**: Extend to publish to Medium, LinkedIn, or other platforms
 * **SEO Optimization**: Include keyword research and meta description generation
 
-```
-
 ### Recipe 2: Automated Social Media Posting
 
 {% hint style="success" %}
@@ -160,7 +158,7 @@ Schedule and automate social media posts using due dates and custom fields. Perf
 
 📱 Social Media Content Calendar ├── 📝 Post Content (task description) ├── 📅 Due Date (posting schedule) ├── 🔖 Status (Draft → Scheduled → Posted) ├── 📊 Platform (Twitter, LinkedIn, Facebook) └── 🎯 Target Audience
 
-````
+```
 
 ```json
 {
@@ -213,7 +211,7 @@ Schedule and automate social media posts using due dates and custom fields. Perf
     }
   ]
 }
-````
+```
 
 **Setup Instructions:**
 

--- a/genesis-living-system-builder/genesis/getting-started.md
+++ b/genesis-living-system-builder/genesis/getting-started.md
@@ -6,9 +6,15 @@
 
 ## What is Taskade Genesis?
 
-Genesis turns a single prompt into a working app.\nIt creates the UI and connects it to your workspace.\nYou iterate by describing changes in plain English.
+Genesis turns a single prompt into a working app.
 
-Want the deeper “why it works” model?\nStart with [Workspace DNA](../../genesis-living-system-builder/genesis/workspace-dna.md).
+It creates the UI and connects it to your workspace.
+
+You iterate by describing changes in plain English.
+
+Want the deeper “why it works” model?
+
+Start with [Workspace DNA](../../genesis-living-system-builder/genesis/workspace-dna.md).
 
 ## Before You Start
 
@@ -58,7 +64,11 @@ Start by thinking about something in your business that could work better. Commo
 ***
 
 {% hint style="info" %}
-Skip the theory.\nFollow the steps below.\nIf you want the underlying model, read [Workspace DNA](../../genesis-living-system-builder/genesis/workspace-dna.md).
+Skip the theory.
+
+Follow the steps below.
+
+If you want the underlying model, read [Workspace DNA](../../genesis-living-system-builder/genesis/workspace-dna.md).
 {% endhint %}
 
 ## Step 2: Craft Your App Description (2 minutes)
@@ -387,4 +397,7 @@ They should [SPECIFIC STEPS], and when they do,
 
 ### Next steps
 
-* Copy a working prompt: [Living System Examples & Templates](examples-and-templates.md)\n- Improve prompts: [Living System Best Practices](../community-and-sharing/best-practices.md)\n- Publish professionally: [Custom Domains & Branding](../space-apps-guide/custom-domains.md)\n- Fix common issues: [Living System Troubleshooting](../community-and-sharing/troubleshooting.md)
+* Copy a working prompt: [Living System Examples & Templates](examples-and-templates.md)
+- Improve prompts: [Living System Best Practices](../community-and-sharing/best-practices.md)
+- Publish professionally: [Custom Domains & Branding](../space-apps-guide/custom-domains.md)
+- Fix common issues: [Living System Troubleshooting](../community-and-sharing/troubleshooting.md)


### PR DESCRIPTION
## Live render-leakage fixes

Found by the post-merge multi-agent **live render audit** of docs.taskade.com (curl across all 191 pages). Two pages had content rendering incorrectly on the live site.

### 1. `automation/recipes.md` — Recipe 2 trapped in a code block

A stray bare ` ``` ` fence opened a code block that swallowed the entire **Recipe 2: Automated Social Media Posting** section — the heading, the `{% hint %}` callout, and its prose all rendered as monospaced code text. Two ````-backtick fences also mismatched their ```-openers.

**Fix:** removed the stray fence; normalized the two closers to 3-backtick. Recipe 2 now renders as a heading + success-hint callout; the project-structure tree and JSON example render as proper code blocks. (Verified: all fences balanced, heading + hint in prose context, 3/3 hints + 2/2 steppers paired.)

### 2. `genesis/getting-started.md` — literal `\n` in prose

Literal backslash-n sequences leaked into the visible Quick Start text (3 prose spots) and collapsed the "what to do next" bullet list into one line. Converted to real paragraph breaks and bullet lines.

### Not changed
`workspaces/markdown.md` keeps `\n` inside **code-span syntax examples** (e.g. `\`1. item\\n2. item\``) — that is an intentional way to show multi-line snippets inside a single Markdown-reference table cell (a code span cannot contain real line breaks).

### Context
Follow-up to #56/#57/#58 (merged). These two defects are pre-existing/deferred render issues surfaced only by fetching the rendered live site. Branched fresh off `main`; disjoint from prior PRs.

🤖 Generated with [Claude Code](https://claude.ai/code)