### PR TITLE
docs: SEO backlinks from hub pages to core taskade.com landing pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ coverY: 0
 
 **The AI-Native Platform for Building Intelligent Applications**
 
-Build complete business applications, websites, and tools using natural language. Taskade combines an **AI app builder**, **workflow automation engine**, **AI agents platform**, and **automatic deployment** into a unified workspace.
+Build complete business applications, websites, and tools using natural language. Taskade combines an **AI app builder** ([Taskade Genesis](https://www.taskade.com/create)), **workflow automation engine**, **AI agents platform**, and **automatic deployment** into a unified workspace.
 
 **Build Without Permission. Start with Genesis. Your workspace is the foundation.**
 

--- a/apis-living-system-development/developer-home.md
+++ b/apis-living-system-development/developer-home.md
@@ -4,7 +4,7 @@ description: Everything you need to build on Taskade — REST API, MCP Server, S
 
 # Build on Taskade
 
-You want to integrate Taskade into your app, automate your workflows, or connect your AI tools. This page gets you started fast.
+You want to integrate Taskade into your app, automate your workflows, or connect your AI tools. This page gets you started fast. Many teams build their app visually with [Taskade Genesis](https://www.taskade.com/create) first, then extend it with the API.
 
 ## Integration Surface at a Glance
 

--- a/genesis-living-system-builder/ai-features/README.md
+++ b/genesis-living-system-builder/ai-features/README.md
@@ -23,7 +23,7 @@ Canonical foundation: [Workspace DNA](../../genesis-living-system-builder/genesi
 
 #### AI agents
 
-Agents are persistent assistants. You can scope them to a workspace, project, or use case.
+Agents are persistent assistants. You can scope them to a workspace, project, or use case. Learn more about [Taskade AI Agents](https://www.taskade.com/agents).
 
 Start here: [AI Agents Getting Started](ai-agents-getting-started.md).
 

--- a/genesis-living-system-builder/ai-features/ai-agents-getting-started.md
+++ b/genesis-living-system-builder/ai-features/ai-agents-getting-started.md
@@ -4,7 +4,7 @@ Transform your workspace with smart AI assistants that understand your business 
 
 ## What are AI Agents?
 
-AI Agents are specialized assistants designed to automate activities like research, data analysis, and content creation. Think of them as smart team members who:
+AI Agents are specialized assistants designed to automate activities like research, data analysis, and content creation. Learn more about [Taskade AI Agents](https://www.taskade.com/agents) and what they can do for your team. Think of them as smart team members who:
 
 * 🧠 **Learn your business** by reading your documents and projects
 * 🤖 **Answer questions** about your work and processes

--- a/genesis-living-system-builder/automation/README.md
+++ b/genesis-living-system-builder/automation/README.md
@@ -79,6 +79,8 @@ Calendly, Slack, Typeform, Gmail, Google Sheets, Google Forms, Google Drive, Web
 
 ### 36 Integration Pieces
 
+Connect your workflows to popular tools across the [Taskade integrations](https://www.taskade.com/integrations) directory.
+
 | Category         | Services                                                             |
 | ---------------- | -------------------------------------------------------------------- |
 | Communication    | Slack, Discord, Microsoft Teams, WhatsApp Business, Telegram Bot     |

--- a/genesis-living-system-builder/community-and-sharing/README.md
+++ b/genesis-living-system-builder/community-and-sharing/README.md
@@ -132,7 +132,7 @@ When you fork a Genesis app, you get:
 
 ### What Happens When You Share?
 
-When you share your Genesis app with the community, it goes into a public library where other business owners can find it, try it out, and copy it for their own use. Think of it like sharing a great recipe—you help others while showing off your skills!
+When you share your Genesis app with the community, it goes into a public library where other business owners can find it, try it out, and copy it for their own use. You can explore the [Taskade community](https://www.taskade.com/community) to see the shared apps, agents, and templates other builders have published. Think of it like sharing a great recipe—you help others while showing off your skills!
 
 ### When to Share with Community
 

--- a/genesis-living-system-builder/genesis/README.md
+++ b/genesis-living-system-builder/genesis/README.md
@@ -7,7 +7,7 @@
 **Imagine it. Run it live.**\
 **Powered by your workspace.**
 
-Genesis turns plain English into a live application.\
+[Taskade Genesis](https://www.taskade.com/create) turns plain English into a live application.\
 It builds on the same data, agents, and automations you already use.
 
 {% hint style="success" %}

--- a/genesis-living-system-builder/genesis/how-genesis-works.md
+++ b/genesis-living-system-builder/genesis/how-genesis-works.md
@@ -31,7 +31,7 @@ This guide explains the core architecture behind **Taskade Genesis** — the AI 
 - **EVE:** How Taskade's unified AI system connects everything together.
 - **Intelligence Score:** How your workspace earns a 0–100 score across 5 maturity tiers.
 
-> **New to Genesis?** Start with [Create Your First App](./getting-started.md) for a hands-on walkthrough.
+> **New to Genesis?** Start with [Create Your First App](./getting-started.md) for a hands-on walkthrough, or jump straight in and build your first app with [Taskade Genesis](https://www.taskade.com/create).
 
 ---
 

--- a/genesis-living-system-builder/workspaces/README.md
+++ b/genesis-living-system-builder/workspaces/README.md
@@ -1,6 +1,6 @@
 # Workspaces: Living DNA Control
 
-Workspaces are the enhanced foundational containers that organize your teams, projects, and resources in Taskade. Each workspace creates an isolated collaborative environment with dedicated members, customizable settings, granular permission controls, and advanced enterprise capabilities.
+Workspaces are the enhanced foundational containers that organize your teams, projects, and resources in Taskade. Each workspace creates an isolated collaborative environment with dedicated members, customizable settings, granular permission controls, and advanced enterprise capabilities. To see how workspaces fit alongside the full set of [Taskade features](https://www.taskade.com/features), explore the complete product overview.
 
 ## 🏢 What is a Workspace?
 

--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -41,7 +41,7 @@ Learn more: [Workspace DNA](https://help.taskade.com/en/articles/12578949-how-ge
 
 ## Build Your First App with Genesis (5 minutes)
 
-**This is where the magic happens.** Instead of managing tasks manually, let's build an app that solves a real business problem.
+**This is where the magic happens.** Instead of managing tasks manually, let's build an app that solves a real business problem. You can [start building your first app with Taskade Genesis](https://www.taskade.com/create) directly from your workspace.
 
 {% stepper %}
 {% step %}


### PR DESCRIPTION
## SEO internal backlinks → core taskade.com landing pages

Adds **one tasteful, descriptive contextual link per high-authority docs hub/overview page** to its matching marketing landing page. docs.taskade.com pages carry domain authority and search traffic; linking them to the core product pages passes that authority and funnels readers toward the product — with **descriptive anchor text** (good for SEO; no "click here").

### Mapping

| Docs page(s) | → Landing page | Anchor |
|---|---|---|
| Home, Developer Hub, Genesis Overview, How Genesis Works, Quick Start | [taskade.com/create](https://www.taskade.com/create) (AI App Builder) | "Taskade Genesis" |
| AI Features Overview, AI Agents Getting Started | [taskade.com/agents](https://www.taskade.com/agents) | "Taskade AI Agents" |
| Automations Overview | [taskade.com/integrations](https://www.taskade.com/integrations) | "Taskade integrations" |
| Workspaces Overview | [taskade.com/features](https://www.taskade.com/features) | "Taskade features" |
| Community & Sharing | [taskade.com/community](https://www.taskade.com/community) | "Taskade community" |

### Approach (tasteful, not spammy)
- Exactly **one** link per page, woven into existing intro/overview copy — e.g. the Developer Hub now reads *"Many teams build their app visually with Taskade Genesis first, then extend it with the API."*
- Additive only — no new salesy paragraphs, no duplicate links.
- All 5 distinct targets verified **200**; left-out 404s (e.g. /download, /automation) and the auth-gated /mcp endpoint.

**10 files, +11/−9.** Branched fresh off `main`; disjoint from prior PRs.

🤖 Generated with [Claude Code](https://claude.ai/code)