### PR TITLE
docs: backfill SEO meta descriptions on 9 section landing pages (C1)

### DIFF
--- a/apis-living-system-development/comprehensive-api-guide/README.md
+++ b/apis-living-system-development/comprehensive-api-guide/README.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade REST API v1 reference — authenticate, then manage workspaces, projects, tasks, agents, folders, and media with full CRUD and an interactive explorer.
+---
+
 # Comprehensive API Guide
 
 Build powerful integrations with Taskade's REST API. Access projects, tasks, agents, and more programmatically with full CRUD operations.

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade changelog archive (2017-2025) — historical release notes, feature launches, and platform updates.
+---
+
 # Changelog (2017 - 2025)
 
 Welcome to Taskade's changelog! This chronicles our extraordinary journey from a simple task management tool to **Genesis** - the world's first AI-powered platform that turns a single prompt into a living, intelligent application.

--- a/genesis-living-system-builder/ai-features/README.md
+++ b/genesis-living-system-builder/ai-features/README.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Deploy custom AI agents with persistent memory, knowledge, and tool access across your Taskade workspace — the intelligence layer behind every app and automation.
+---
+
 # AI Features Overview
 
 **Think. Learn. Adapt.** Taskade AI features form the living intelligence layer of Workspace DNA, creating systems that understand, evolve, and provide increasingly intelligent value with every interaction.

--- a/genesis-living-system-builder/automation/README.md
+++ b/genesis-living-system-builder/automation/README.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Automate work 24/7 with Taskade's trigger-and-action engine — connect 100+ integrations and let AI agents run your workflows from start to finish.
+---
+
 # Automations Overview
 
 **Act. Execute. Evolve.** Taskade Automations are the living motion layer of Workspace DNA, transforming static workflows into intelligent, adaptive systems that act with precision and learn from every execution.

--- a/genesis-living-system-builder/community-and-sharing/README.md
+++ b/genesis-living-system-builder/community-and-sharing/README.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Share, publish, and clone Taskade apps and templates — collaborate with your team or ship to the community with public links and custom domains.
+---
+
 # Sharing: Living Systems
 
 **Turn your brilliant Genesis app into something that helps business owners everywhere. Share what you've built, discover amazing solutions from others, and copy complete apps with just one click.**

--- a/genesis-living-system-builder/genesis/README.md
+++ b/genesis-living-system-builder/genesis/README.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade Genesis turns natural-language prompts into full applications — databases, interfaces, automations, and AI agents — deployed instantly from your workspace.
+---
+
 # Taskade Genesis Overview
 
 **Living Software. Living DNA. Living Intelligence.**

--- a/genesis-living-system-builder/space-apps-guide/README.md
+++ b/genesis-living-system-builder/space-apps-guide/README.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Publish Genesis apps as real products — add custom domains, branding, advanced features, and styling to turn your workspace into a live application.
+---
+
 # Space Apps: Living Systems
 
 **Create professional websites and web applications just by describing what you want. No coding, no hosting headaches—just your idea turned into a live website that works everywhere.**

--- a/genesis-living-system-builder/workspaces/README.md
+++ b/genesis-living-system-builder/workspaces/README.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Organize everything in Taskade workspaces — projects, tasks, members, and billing — the structured-data foundation that powers apps, agents, and automations.
+---
+
 # Workspaces: Living DNA Control
 
 Workspaces are the enhanced foundational containers that organize your teams, projects, and resources in Taskade. Each workspace creates an isolated collaborative environment with dedicated members, customizable settings, granular permission controls, and advanced enterprise capabilities. To see how workspaces fit alongside the full set of [Taskade features](https://www.taskade.com/features), explore the complete product overview.

--- a/help-center/README.md
+++ b/help-center/README.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Find answers about Taskade — Genesis app building, AI agents, automations, workspaces, billing, and troubleshooting, organized by topic.
+---
+
 # Help Center
 
 Find answers fast. Pick the topic that matches what you need.


### PR DESCRIPTION
## SEO: backfill `<meta name="description">` on section landing pages (C1)

The live audit found **~70% of pages ship an empty `<meta name="description">`** because only the recently-added developer-platform pages carried frontmatter `description:`. Empty descriptions force search engines to auto-generate snippets. This PR adds concise, keyword-rich `description:` frontmatter to the 9 most-visited **section landing pages**, each flowing automatically to `<meta name="description">`, `og:description`, and `twitter:description`.

| Page | New description (≤160 chars) |
|------|------------------------------|
| Genesis Overview | Genesis turns natural-language prompts into full applications — databases, interfaces, automations, AI agents — deployed instantly |
| AI Features Overview | Deploy custom AI agents with persistent memory, knowledge, and tool access — the intelligence layer behind every app and automation |
| Automations Overview | Automate work 24/7 with the trigger-and-action engine — 100+ integrations, AI agents running workflows end to end |
| Workspaces Overview | Organize projects, tasks, members, and billing — the structured-data foundation powering apps, agents, and automations |
| Community & Sharing | Share, publish, and clone apps and templates — collaborate or ship to the community with public links and custom domains |
| Space Apps Guide | Publish Genesis apps as real products — custom domains, branding, advanced features, and styling |
| REST API v1 Guide | Authenticate, then manage workspaces, projects, tasks, agents, folders, and media with full CRUD and an interactive explorer |
| Help Center | Find answers — Genesis, AI agents, automations, workspaces, billing, troubleshooting, organized by topic |
| Changelog (2017–2025) | Changelog archive — historical release notes, feature launches, and platform updates |

### Scope / safety
- Frontmatter-only additions (`+45 / −0`, 9 files). No body/structure changes — H1s and content untouched.
- File set is **disjoint** from the render-trust (#61) and link-rot (#62) PRs, so all three merge independently.
- Uses GitBook's standard folded-scalar frontmatter; descriptions stay under ~160 chars for clean SERP/social rendering.

> Note: per-endpoint REST pages derive their description from the OpenAPI block (not page frontmatter) and aren't included here. C2 (JSON-LD) and C3 (per-section og:image) are **not exposed by the GitBook site-customization API** — reported separately rather than forced.

🤖 Generated with [Claude Code](https://claude.ai/code)
