### PR TITLE
docs: dedupe developer landing title ('Build on Taskade' -> 'Developer Platform')

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Use this as the canonical overview: [Workspace DNA](genesis-living-system-builde
 
 #### 💻 **For Developers**
 
-* [**Build on Taskade**](apis-living-system-development/developer-home.md) - The developer portal: APIs, SDK, and MCP
+* [**Developer Platform**](apis-living-system-development/developer-home.md) - The developer portal: APIs, SDK, and MCP
 * [**REST API v1**](apis-living-system-development/comprehensive-api-guide/README.md) - Complete RESTful reference (full task CRUD)
 * [**Action API v2**](apis-living-system-development/api-v2-reference.md) - The newer action-based API (agent prompting, bundles)
 * [**Authentication**](apis-living-system-development/developers/authentication.md) - Personal tokens & OAuth 2.0

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -12,7 +12,7 @@
 
 ## APIs & Developer
 
-* [Build on Taskade](apis-living-system-development/developer-home.md)
+* [Developer Platform](apis-living-system-development/developer-home.md)
   * [Developer Overview](apis-living-system-development/developers/README.md)
 * [Authentication](apis-living-system-development/developers/authentication.md)
   * [Personal Tokens](apis-living-system-development/developers/personal-tokens.md)

--- a/apis-living-system-development/developer-home.md
+++ b/apis-living-system-development/developer-home.md
@@ -2,7 +2,7 @@
 description: Everything you need to build on Taskade — REST API, MCP Server, SDK, and more.
 ---
 
-# Build on Taskade
+# Developer Platform
 
 You want to integrate Taskade into your app, automate your workflows, or connect your AI tools. This page gets you started fast. Many teams build their app visually with [Taskade Genesis](https://www.taskade.com/create) first, then extend it with the API.
 


### PR DESCRIPTION
## Nav clarity + duplicate-title fix (B4 + sidebar)

The developer hub (`developer-home.md`) had the **same title as the site home** ('Build on Taskade'), causing two problems verified live:
1. The left sidebar listed **'Build on Taskade' twice** — once as the home entry, once as the APIs & Developer landing (confusing, per the nav screenshot).
2. Both pages emitted an identical `<title>Build on Taskade | Taskade Docs</title>` — weak for SEO/CTR (duplicate titles).

### Change
| File | From | To |
|------|------|-----|
| `developer-home.md` | H1 `# Build on Taskade` | `# Developer Platform` |
| `SUMMARY.md` | sidebar label `[Build on Taskade]` | `[Developer Platform]` |
| `README.md` | home link text `[**Build on Taskade**]` → dev hub | `[**Developer Platform**]` |

Home page keeps its own `# Build on Taskade` H1.

### Zero-regression
- **Labels/headings only** — no filenames, paths, or slugs change, so every internal link and the `/apis-and-developer/developer-home` URL keep working.
- Distinct from the section landing's child page 'Developer Overview' (`developers/README.md`), which is unchanged.

🤖 Generated with [Claude Code](https://claude.ai/code)