### PR TITLE
docs: home meta description concise + complete (A4 final)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 ---
-description: >-
-  The productivity platform with living DNA. Your workspace becomes a digital
-  organism where every project, agent, automation, and piece of knowledge
-  connects to form the genetic code of everything you build.
+description: Build apps, deploy AI agents, and automate workflows on Taskade — the AI-native platform with living DNA where projects, agents, and automations connect as one.
 cover: .gitbook/assets/ss-api3.png
 coverY: 0
 ---


### PR DESCRIPTION
## Fix truncated home meta description (A4, definitive)

PR #61 appended 'build.' to the home `description:`, but live QA showed the `<meta name="description">`, `og:description`, `twitter:description`, and rendered hero `<p>` **still truncated at '…everything you'**.

**Root cause:** the description was 206 characters; GitBook caps the rendered meta description at ~200 chars on a word boundary, so '… build.' (chars 200–206) was dropped. Appending a word couldn't fix a length-cap problem.

**Fix:** rewrite to a self-contained **160-char** description that renders in full and leads with high-value keywords:
> Build apps, deploy AI agents, and automate workflows on Taskade — the AI-native platform with living DNA where projects, agents, and automations connect as one.

Frontmatter-only change to `README.md`; cover/coverY and body untouched. Verified length < 200 so it renders complete; aligns with the ≤160-char SEO sweet spot.

🤖 Generated with [Claude Code](https://claude.ai/code)