### PR TITLE
docs: migrate all help.taskade.com links to www.taskade.com/learn (23 URLs, 55 occurrences)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ Software should be alive. And now, it is.
 
 | Capability               | Description                                                    | Learn More                                                                                                  |
 | ------------------------ | -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| **AI App Builder**       | Generate full-stack applications from natural language prompts | [Create Your First App →](https://help.taskade.com/en/articles/11957643-create-your-first-app)              |
-| **Website Generator**    | Create responsive websites with built-in AI intelligence       | [Workspace DNA →](https://help.taskade.com/en/articles/12578949-how-genesis-works-workspace-dna)            |
-| **Workflow Automation**  | Connect 100+ integrations with AI-powered decision making      | [Automations Guide →](https://help.taskade.com/en/articles/8958467-automations-the-execution-pillar)        |
-| **AI Agents Platform**   | Deploy custom AI assistants with persistent memory             | [Custom AI Agents →](https://help.taskade.com/en/articles/8958457-custom-ai-agents-the-intelligence-pillar) |
-| **Projects & Databases** | Structured data with real-time sync and custom fields          | [Memory Pillar →](https://help.taskade.com/en/articles/12166149-projects-databases-the-memory-pillar)       |
+| **AI App Builder**       | Generate full-stack applications from natural language prompts | [Create Your First App →](https://www.taskade.com/learn/genesis/first-app)              |
+| **Website Generator**    | Create responsive websites with built-in AI intelligence       | [Workspace DNA →](https://www.taskade.com/learn/genesis/workspace-dna)            |
+| **Workflow Automation**  | Connect 100+ integrations with AI-powered decision making      | [Automations Guide →](https://www.taskade.com/learn/automation/automations-execution)        |
+| **AI Agents Platform**   | Deploy custom AI assistants with persistent memory             | [Custom AI Agents →](https://www.taskade.com/learn/agents/custom-agents) |
+| **Projects & Databases** | Structured data with real-time sync and custom fields          | [Memory Pillar →](https://www.taskade.com/learn/projects/databases)       |
 
 [**Start Building →**](https://www.taskade.com) | [**Browse Community Apps →**](https://www.taskade.com/community)
 

--- a/apis-living-system-development/comprehensive-api-guide/agents/README.md
+++ b/apis-living-system-development/comprehensive-api-guide/agents/README.md
@@ -12,8 +12,8 @@ These endpoints allow you to create, manage, and interact with the AI Agents tha
 
 ### Learn More
 
-* [**Custom AI Agents ›**](https://help.taskade.com/en/articles/8958457-custom-ai-agents)
-* [**Tools for AI Agents ›**](https://help.taskade.com/en/articles/9314171-tools-for-ai-agents)
+* [**Custom AI Agents ›**](https://www.taskade.com/learn/agents/custom-agents)
+* [**Tools for AI Agents ›**](https://www.taskade.com/learn/agents/agent-tools)
 
 ## Summary of Endpoints
 

--- a/apis-living-system-development/comprehensive-api-guide/agents/inbound-webhooks.md
+++ b/apis-living-system-development/comprehensive-api-guide/agents/inbound-webhooks.md
@@ -25,4 +25,4 @@ An example of the following WebHook Trigger and its associated data is shown her
 
 <figure><img src="../../../.gitbook/assets/image (1).png" alt=""><figcaption></figcaption></figure>
 
-Setting up an inbound webhook involves setting up an automation flow. More information can be found here in our help center here: [https://help.taskade.com/en/articles/8958467-getting-started-with-automation](https://help.taskade.com/en/articles/8958467-getting-started-with-automation)
+Setting up an inbound webhook involves setting up an automation flow. Learn more in the [Taskade Automation guide](https://www.taskade.com/learn/automation).

--- a/apis-living-system-development/comprehensive-api-guide/projects/README.md
+++ b/apis-living-system-development/comprehensive-api-guide/projects/README.md
@@ -15,7 +15,7 @@ These endpoints allow you to create, read, update, and delete the Projects that 
 
 ### Learn More
 
-* [**Agent Knowledge & Memory ›**](https://help.taskade.com/en/articles/9495190-agent-knowledge-memory)
+* [**Agent Knowledge & Memory ›**](https://www.taskade.com/learn/agents/knowledge)
 
 ## Summary of Endpoints
 

--- a/apis-living-system-development/developers/README.md
+++ b/apis-living-system-development/developers/README.md
@@ -13,9 +13,9 @@ Taskade provides a complete platform for building intelligent applications:
 | Capability              | Description                                            | Learn More                                                                                                 |
 | ----------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
 | **AI App Builder**      | Generate full-stack applications from natural language | [Taskade Genesis →](../../genesis-living-system-builder/genesis/)                                          |
-| **AI Agents Platform**  | Custom assistants with knowledge retrieval             | [AI Agents Guide →](https://help.taskade.com/en/articles/8958457-custom-ai-agents-the-intelligence-pillar) |
-| **Workflow Automation** | Event-driven processing with 100+ integrations         | [Automations →](https://help.taskade.com/en/articles/8958467-automations-the-execution-pillar)             |
-| **Projects & Data**     | Structured data with real-time sync and custom fields  | [Projects Guide →](https://help.taskade.com/en/articles/12166149-projects-databases-the-memory-pillar)     |
+| **AI Agents Platform**  | Custom assistants with knowledge retrieval             | [AI Agents Guide →](https://www.taskade.com/learn/agents/custom-agents) |
+| **Workflow Automation** | Event-driven processing with 100+ integrations         | [Automations →](https://www.taskade.com/learn/automation/automations-execution)             |
+| **Projects & Data**     | Structured data with real-time sync and custom fields  | [Projects Guide →](https://www.taskade.com/learn/projects/databases)     |
 
 The API is built around real-time data synchronization and a unified intelligence layer that powers everything from simple CRUD operations to complex AI-driven workflows.
 
@@ -101,7 +101,7 @@ Official libraries and tools:
 
 Build complete web applications from natural language prompts. Taskade Genesis handles code generation and automatic deployment.
 
-[**Create Your First App →**](https://help.taskade.com/en/articles/11957643-create-your-first-app)
+[**Create Your First App →**](https://www.taskade.com/learn/genesis/first-app)
 
 ## 📚 Resources
 

--- a/automation/triggers.md
+++ b/automation/triggers.md
@@ -2,7 +2,7 @@
 
 Triggers are the "if" part of automation workflows—they define the events that initiate automated actions. Taskade provides a comprehensive set of triggers that monitor for task changes, project events, external integrations, and scheduled conditions.
 
-**[Automations Guide →](https://help.taskade.com/en/articles/8958467-automations-the-execution-pillar)**
+**[Automations Guide →](https://www.taskade.com/learn/automation/automations-execution)**
 
 {% hint style="success" %}
 Triggers act as the intelligent sensors of your automation system, detecting events across Taskade and external services to initiate workflows.

--- a/features/ai-features/automation-getting-started.md
+++ b/features/ai-features/automation-getting-started.md
@@ -205,7 +205,7 @@ Ready to automate your workflow?
 
 **Need more help?**
 - [Complete Integration Reference](../../automation/comprehensive-integrations.md) - All available triggers and actions
-- [AI Automation Collection](https://help.taskade.com/en/collections/8400803-ai-automation) - Advanced tutorials
+- [AI Automation Collection](https://www.taskade.com/learn/automation) - Advanced tutorials
 - [Community Forum](https://www.taskade.com/community) - Get help from other users
 
 ---

--- a/genesis-living-system-builder/ai-features/README.md
+++ b/genesis-living-system-builder/ai-features/README.md
@@ -39,7 +39,7 @@ Most “smartness” comes from the knowledge you give agents. That includes pro
 Start here:
 
 * [Workspace DNA](../../genesis-living-system-builder/genesis/workspace-dna.md)
-* [Agent Knowledge & Memory](https://help.taskade.com/en/articles/9495190-agent-knowledge-memory)
+* [Agent Knowledge & Memory](https://www.taskade.com/learn/agents/knowledge)
 
 #### Tools (what agents can do)
 

--- a/genesis-living-system-builder/ai-features/autopilot.md
+++ b/genesis-living-system-builder/ai-features/autopilot.md
@@ -166,6 +166,6 @@ After Autopilot generates your initial workspace, expand it with these tools:
 
 | Guide | What You'll Learn |
 |---|---|
-| [How Genesis Works](https://help.taskade.com/en/collections/14476419-taskade-genesis) | Build deployable apps from your workspace |
+| [How Genesis Works](https://www.taskade.com/learn/genesis) | Build deployable apps from your workspace |
 | [Workflow Generator](../automation/workflow-generator.md) | Build automations with natural language |
 | [Taskade for Teams](../workspaces/teams.md) | Organize teams within your workspace |

--- a/genesis-living-system-builder/ai-features/image-generation.md
+++ b/genesis-living-system-builder/ai-features/image-generation.md
@@ -45,7 +45,7 @@ You can generate images for your Taskade Genesis apps **natively** — no extra 
 | 4 | Send the message and wait for generation |
 | 5 | Use immediately in your app, or access anytime from the **Media** tab |
 
-> **Note:** Images generated in chat automatically appear in Media and count toward your AI credit usage. See [Taskade AI Credits](https://help.taskade.com/en/articles/8958455-taskade-ai-credits).
+> **Note:** Images generated in chat automatically appear in Media and count toward your AI credit usage. See [Taskade AI Credits](https://www.taskade.com/learn/agents/ai-usage).
 
 <!-- Screenshot: EVE chat with generated image result -->
 

--- a/genesis-living-system-builder/ai-features/media-ai-chat.md
+++ b/genesis-living-system-builder/ai-features/media-ai-chat.md
@@ -145,4 +145,4 @@ Every media interaction enriches your workspace:
 | [Adding Genesis Context](../genesis/adding-context.md) | Use media files as context for app building |
 | [Agent Knowledge & Memory](./agent-knowledge.md) | Train agents on your media files |
 | [Image Generation](./image-generation.md) | Generate new images to add to your media library |
-| [Taskade AI Credits](https://help.taskade.com/en/articles/8958455-taskade-ai-credits) | Understand credit usage for media AI interactions |
+| [Taskade AI Credits](https://www.taskade.com/learn/agents/ai-usage) | Understand credit usage for media AI interactions |

--- a/genesis-living-system-builder/automation/comprehensive-integrations.md
+++ b/genesis-living-system-builder/automation/comprehensive-integrations.md
@@ -1,6 +1,6 @@
 # Comprehensive Integrations
 
-This document provides a complete reference of all available integrations, triggers, and actions in Taskade's automation system. For getting started guides, visit the [Taskade Help Center](https://help.taskade.com/en/articles/8958467-getting-started-with-automation) and [AI Automation Collection](https://help.taskade.com/en/collections/8400803-ai-automation).
+This document provides a complete reference of all available integrations, triggers, and actions in Taskade's automation system. For getting started guides, visit the [Taskade Help Center](https://www.taskade.com/learn/automation) and [AI Automation Collection](https://www.taskade.com/learn/automation).
 
 ## Core Taskade Tools
 
@@ -496,23 +496,23 @@ This document provides a complete reference of all available integrations, trigg
 
 ### App Triggers
 
-* **Forms**: [AI Forms Documentation](https://help.taskade.com/en/articles/9711589-ai-forms-automation-trigger)
-* **Webhooks**: [Webhooks Documentation](https://help.taskade.com/en/articles/9494976-webhooks-automation-trigger)
+* **Forms**: [AI Forms Documentation](https://www.taskade.com/learn/automation/forms-trigger)
+* **Webhooks**: [Webhooks Documentation](https://www.taskade.com/learn/automation/webhook-trigger)
 * **Agent Triggers**: Built-in agent conversation triggers
 
 ### Control Actions
 
 * **Delay**: Wait/Sleep actions for timing control
-* **Branch**: [Conditional logic documentation](https://help.taskade.com/en/articles/9805047-branch-automation-action)
-* **Loop**: [Iteration control documentation](https://help.taskade.com/en/articles/10351362-loop-automation-action)
-* **Filter Data**: [Data filtering documentation](https://help.taskade.com/en/articles/9615031-filter-data-automation-action)
+* **Branch**: [Conditional logic documentation](https://www.taskade.com/learn/automation/branch-action)
+* **Loop**: [Iteration control documentation](https://www.taskade.com/learn/automation/loop-action)
+* **Filter Data**: [Data filtering documentation](https://www.taskade.com/learn/automation/filter-data)
 
 ## Getting Started
 
 To learn more about setting up and using these integrations:
 
-1. [**Getting Started with Automation**](https://help.taskade.com/en/articles/8958467-getting-started-with-automation) - Complete beginner's guide
-2. [**AI Automation Collection**](https://help.taskade.com/en/collections/8400803-ai-automation) - All automation resources
+1. [**Getting Started with Automation**](https://www.taskade.com/learn/automation) - Complete beginner's guide
+2. [**AI Automation Collection**](https://www.taskade.com/learn/automation) - All automation resources
 3. [**Community Forum**](https://www.taskade.com/community) - Get help from the community
 4. [**Developer API**](../../apis-living-system-development/developers/api.md) - Build custom integrations
 

--- a/genesis-living-system-builder/automation/workflow-generator.md
+++ b/genesis-living-system-builder/automation/workflow-generator.md
@@ -20,7 +20,7 @@
 
 The Workflow Generator builds complex automation flows from **natural language**. Describe what you want in plain English, and the AI creates complete workflows with triggers, conditions, branches, loops, and integrations across 100+ services — no drag-and-drop, no manual configuration.
 
-> **Genesis connection:** Genesis apps automatically generate workflow automations as part of the Execution pillar. The Workflow Generator lets you create additional automations or modify existing ones. Each automation adds **+5 points** to your [Intelligence Score](https://help.taskade.com/en/collections/14476419-taskade-genesis).
+> **Genesis connection:** Genesis apps automatically generate workflow automations as part of the Execution pillar. The Workflow Generator lets you create additional automations or modify existing ones. Each automation adds **+5 points** to your [Intelligence Score](https://www.taskade.com/learn/genesis).
 
 ---
 

--- a/genesis-living-system-builder/community-and-sharing/README.md
+++ b/genesis-living-system-builder/community-and-sharing/README.md
@@ -605,9 +605,9 @@ const communityData = await response.json();
 
 ### Community Documentation
 
-* [**Community Guidelines**](https://help.taskade.com/en/articles/12123045-genesis-community-apps) - Rules and best practices
-* [**Publishing Checklist**](https://help.taskade.com/en/articles/12165353-publish-and-clone-your-apps) - Pre-publication review steps
-* [**Community Success Tips**](https://help.taskade.com/en/articles/10577446-contribute-share-and-grow-with-taskade) - Growing your presence
+* [**Community Guidelines**](https://www.taskade.com/learn/genesis/community-gallery) - Rules and best practices
+* [**Publishing Checklist**](https://www.taskade.com/learn/genesis/publishing) - Pre-publication review steps
+* [**Community Success Tips**](https://www.taskade.com/learn/genesis/community-kits) - Growing your presence
 
 ### Getting Help
 

--- a/genesis-living-system-builder/community-and-sharing/faq.md
+++ b/genesis-living-system-builder/community-and-sharing/faq.md
@@ -244,7 +244,7 @@ Yes! Most plans include a **free trial period** where you can test advanced feat
 
 **Self-service resources:**
 
-* **Help documentation:** [help.taskade.com](https://help.taskade.com/en/collections/14476419-taskade-genesis)
+* **Help documentation:** [help.taskade.com](https://www.taskade.com/learn/genesis)
 * **Video tutorials:** [youtube.com/taskade](https://youtube.com/taskade)
 * **Community forums:** Connect with other users
 * **This documentation:** Comprehensive guides and examples
@@ -372,7 +372,7 @@ See our [Best Practices guide](best-practices.md) for detailed examples.
 
 **Still have questions?**
 
-* **Browse our help center:** [help.taskade.com](https://help.taskade.com/en/collections/14476419-taskade-genesis)
+* **Browse our help center:** [help.taskade.com](https://www.taskade.com/learn/genesis)
 * **Email us:** [support@taskade.com](mailto:support@taskade.com)
 * **Join the community:** [taskade.com/community](https://taskade.com/community)
 

--- a/genesis-living-system-builder/community-and-sharing/publish-and-clone.md
+++ b/genesis-living-system-builder/community-and-sharing/publish-and-clone.md
@@ -206,7 +206,7 @@ Connect your own domain to any published Genesis app:
 | [Genesis Version History](../genesis/version-history.md) | Track changes and restore previous versions |
 | [App Analytics](../genesis/app-analytics.md) | Monitor visitor data and optimize your app |
 | [Create Your First App](../genesis/getting-started.md) | Build something to publish |
-| [Taskade AI Credits](https://help.taskade.com/en/articles/8958455-taskade-ai-credits) | Understand credit costs for app operations |
+| [Taskade AI Credits](https://www.taskade.com/learn/agents/ai-usage) | Understand credit costs for app operations |
 | [Sharing Best Practices](best-practices.md) | Tips for collaborating and distributing apps |
 | [Sharing FAQ](faq.md) | Common questions about publishing and access |
 | [Developer Platform](../../apis-living-system-development/developer-home.md) | Publish and manage apps programmatically via the API |

--- a/genesis-living-system-builder/genesis/getting-started.md
+++ b/genesis-living-system-builder/genesis/getting-started.md
@@ -358,7 +358,7 @@ Congratulations! You've built your first Genesis app. Here's how to take it furt
 
 ### **Get Help**
 
-* **Help Center:** [help.taskade.com](https://help.taskade.com/en/collections/14476419-taskade-genesis)
+* **Help Center:** [help.taskade.com](https://www.taskade.com/learn/genesis)
 * **Video Tutorials:** [youtube.com/taskade](https://youtube.com/taskade)
 * **Community:** [taskade.com/community](https://taskade.com/community)
 * **Email Support:** [support@taskade.com](mailto:support@taskade.com)

--- a/genesis-living-system-builder/genesis/how-genesis-works.md
+++ b/genesis-living-system-builder/genesis/how-genesis-works.md
@@ -53,7 +53,7 @@ A single prompt gives you:
 | **Version Control** | Full commit history with one-click restore to any previous version |
 | **Publishing** | Instant deployment with shareable links, custom domains, and community gallery |
 
-> **Genesis hint:** Your AI credits power app creation. Different models have different credit costs — see [Taskade AI Credits](https://help.taskade.com/en/articles/8958455-taskade-ai-credits) for details.
+> **Genesis hint:** Your AI credits power app creation. Different models have different credit costs — see [Taskade AI Credits](https://www.taskade.com/learn/agents/ai-usage) for details.
 
 ---
 

--- a/genesis-living-system-builder/space-apps-guide/custom-domains.md
+++ b/genesis-living-system-builder/space-apps-guide/custom-domains.md
@@ -564,10 +564,10 @@ _"Custom domain client assessments at assessment.myconsulting.com helped us clos
 
 ### Support Resources
 
-* [**Custom Domain Setup Guide**](https://help.taskade.com/en/articles/10443706-cname-custom-domain) - Step-by-step instructions
-* [**DNS Configuration Examples**](https://help.taskade.com/en/articles/10443706-cname-custom-domain) - Registrar-specific guides
-* [**Branding Best Practices**](https://help.taskade.com/en/articles/12165353-publish-and-clone-your-apps) - Professional presentation tips
-* [**Troubleshooting Guide**](https://help.taskade.com/en/articles/10443706-cname-custom-domain) - Common issues and solutions
+* [**Custom Domain Setup Guide**](https://www.taskade.com/learn/genesis/custom-domains) - Step-by-step instructions
+* [**DNS Configuration Examples**](https://www.taskade.com/learn/genesis/custom-domains) - Registrar-specific guides
+* [**Branding Best Practices**](https://www.taskade.com/learn/genesis/publishing) - Professional presentation tips
+* [**Troubleshooting Guide**](https://www.taskade.com/learn/genesis/custom-domains) - Common issues and solutions
 
 ***
 

--- a/genesis-living-system-builder/workspaces/project-views.md
+++ b/genesis-living-system-builder/workspaces/project-views.md
@@ -2,7 +2,7 @@
 
 Taskade stores information in a flexible tree-structured database. The **same data** can be visualized in multiple ways to suit different workflows. These presentation modes are called **Project Views**.
 
-**[Projects & Databases Guide →](https://help.taskade.com/en/articles/12166149-projects-databases-the-memory-pillar)**
+**[Projects & Databases Guide →](https://www.taskade.com/learn/projects/databases)**
 
 ## Views Reference
 

--- a/genesis-living-system-builder/workspaces/teams.md
+++ b/genesis-living-system-builder/workspaces/teams.md
@@ -152,11 +152,11 @@ Taskade uses a **5-role, 7-tier RBAC** permission system:
 | Feature | How It Helps Teams | Learn More |
 |---|---|---|
 | **Taskade Autopilot** | Generate entire team workspaces from a single prompt | [Taskade Autopilot](../ai-features/autopilot.md) |
-| **AI Agents** | Create specialist agents for each department | [Custom AI Agents](https://help.taskade.com/en/collections/14476419-taskade-genesis) |
-| **Multi-Agent Teams** | Teams of agents that collaborate (Business+) | [Multi-Agents](https://help.taskade.com/en/collections/14476419-taskade-genesis) |
+| **AI Agents** | Create specialist agents for each department | [Custom AI Agents](https://www.taskade.com/learn/genesis) |
+| **Multi-Agent Teams** | Teams of agents that collaborate (Business+) | [Multi-Agents](https://www.taskade.com/learn/genesis) |
 | **Automation Workflows** | Automate cross-department processes | [Automation Triggers](../automation/README.md) |
-| **Genesis Apps** | Build internal tools and dashboards for teams | [Taskade Genesis](https://help.taskade.com/en/collections/14476419-taskade-genesis) |
-| **Shared Agent Chats** | AI + human conversations together | [Custom AI Agents](https://help.taskade.com/en/collections/14476419-taskade-genesis) |
+| **Genesis Apps** | Build internal tools and dashboards for teams | [Taskade Genesis](https://www.taskade.com/learn/genesis) |
+| **Shared Agent Chats** | AI + human conversations together | [Custom AI Agents](https://www.taskade.com/learn/genesis) |
 | **Version History** | Track all changes across team projects | [Version History](../genesis/version-history.md) |
 | **Real-time Collaboration** | Multiple users editing simultaneously (OT-based) | Built-in |
 

--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -24,7 +24,7 @@ Three things power everything:
 * **Intelligence** = AI agents that reason over your data
 * **Execution** = automations that run workflows 24/7
 
-Learn more: [Workspace DNA](https://help.taskade.com/en/articles/12578949-how-genesis-works-workspace-dna)
+Learn more: [Workspace DNA](https://www.taskade.com/learn/genesis/workspace-dna)
 
 ***
 

--- a/help-center/ai-features/README.md
+++ b/help-center/ai-features/README.md
@@ -15,13 +15,13 @@ New to Taskade AI? Start here:
 ### AI Agents: Smart Assistants
 
 - **[AI Agents Getting Started](ai-agents-getting-started.md)** - Create your first AI team member
-- **[Tools for AI Agents](https://help.taskade.com/en/articles/9314171-tools-for-ai-agents)** - Add superpowers to your agents
-- **[Agent Knowledge & Memory](https://help.taskade.com/en/articles/9495190-agent-knowledge-memory)** - Train agents with your data
+- **[Tools for AI Agents](https://www.taskade.com/learn/agents/agent-tools)** - Add superpowers to your agents
+- **[Agent Knowledge & Memory](https://www.taskade.com/learn/agents/knowledge)** - Train agents with your data
 
 ### Automation: Put Work on Autopilot
 
 - **[Automation Getting Started](automation-getting-started.md)** - Automate your first workflow
-- **[Getting Started with Automation](https://help.taskade.com/en/articles/8958467-getting-started-with-automation)** - Official automation guide
+- **[Getting Started with Automation](https://www.taskade.com/learn/automation)** - Official automation guide
 
 ## 💡 What You Can Build
 

--- a/help-center/ai-features/automation-getting-started.md
+++ b/help-center/ai-features/automation-getting-started.md
@@ -177,7 +177,7 @@ Ready to automate your workflow?
 
 **Need more help?**
 - [Complete Integration Reference](../../automation/comprehensive-integrations.md) - All available triggers and actions
-- [AI Automation Collection](https://help.taskade.com/en/collections/8400803-ai-automation) - Advanced tutorials
+- [AI Automation Collection](https://www.taskade.com/learn/automation) - Advanced tutorials
 - [Community Forum](https://www.taskade.com/community) - Get help from other users
 
 ---

--- a/help-center/integrations/README.md
+++ b/help-center/integrations/README.md
@@ -5,8 +5,8 @@ Connect Taskade with the apps you already use every day! Our integrations help y
 
 ## Available Integrations
 
-- [Getting Started with Automation](https://help.taskade.com/en/articles/8958467-getting-started-with-automation) - Complete automation guide
-- [AI Automation Collection](https://help.taskade.com/en/collections/8400803-ai-automation) - All automation resources
+- [Getting Started with Automation](https://www.taskade.com/learn/automation) - Complete automation guide
+- [AI Automation Collection](https://www.taskade.com/learn/automation) - All automation resources
 - [Complete Integration Reference](../../automation/integrations.md) - All available triggers and actions
 - **Calendar Sync** - Sync with Google Calendar, Outlook, and more
 - # **API & Webhooks** - Build custom integrations

--- a/updates-and-timeline/changelog-2026/february-2026/february-6-2026.md
+++ b/updates-and-timeline/changelog-2026/february-2026/february-6-2026.md
@@ -12,7 +12,7 @@ The image preview for your Taskade apps, when shared, has been updated to displa
 
 ### Space Icon -> Favicons
 
-App favicons are now based on your space icons. Choose an emoji or upload an image as your [space icon](https://help.taskade.com/en/articles/8958485-edit-a-workspace-app) and watch it show up as your app's favicon.
+App favicons are now based on your space icons. Choose an emoji or upload an image as your [space icon](https://www.taskade.com/learn/genesis/visual-editor) and watch it show up as your app's favicon.
 
 <figure><img src="../../../.gitbook/assets/CleanShot 2026-02-04 at 16.15.06@2x (1).png" alt=""><figcaption></figcaption></figure>
 


### PR DESCRIPTION
## Migrate help.taskade.com → www.taskade.com/learn (phase-out)

`help.taskade.com` is being retired. This migrates **every** legacy help-center link in the live docs to its **best-fit `www.taskade.com/learn/*`** article. Mapping was built against the live `/learn` sitemap (374-page catalog) and each target verified **HTTP 200**; the 4 ambiguous ones were resolved by reading actual article content (best fit, not slug guess).

**Scope:** 23 unique URLs → 55 occurrences across 26 in-nav pages. `archive/` (not in nav) intentionally untouched.

| Legacy help.taskade.com article | → www.taskade.com/learn | n |
|---|---|---|
| `…/8958467-getting-started-with-automation` | `/learn/automation` | 6 |
| `collections/14476419-taskade-genesis` | `/learn/genesis` | 9 |
| `collections/8400803-ai-automation` | `/learn/automation` | 5 |
| `…/8958455-taskade-ai-credits` | `/learn/agents/ai-usage` ¹ | 4 |
| `…/12166149-projects-databases-the-memory-pillar` | `/learn/projects/databases` | 3 |
| `…/8958467-automations-the-execution-pillar` | `/learn/automation/automations-execution` | 3 |
| `…/9495190-agent-knowledge-memory` | `/learn/agents/knowledge` | 3 |
| `…/10443706-cname-custom-domain` | `/learn/genesis/custom-domains` | 3 |
| `…/8958457-custom-ai-agents(-the-intelligence-pillar)` | `/learn/agents/custom-agents` | 3 |
| `…/12578949-how-genesis-works-workspace-dna` | `/learn/genesis/workspace-dna` | 2 |
| `…/12165353-publish-and-clone-your-apps` | `/learn/genesis/publishing` | 2 |
| `…/11957643-create-your-first-app` | `/learn/genesis/first-app` | 2 |
| `…/9314171-tools-for-ai-agents` | `/learn/agents/agent-tools` | 2 |
| `…/10577446-contribute-share-and-grow` | `/learn/genesis/community-kits` | 1 |
| `…/12123045-genesis-community-apps` | `/learn/genesis/community-gallery` | 1 |
| `…/8958485-edit-a-workspace-app` | `/learn/genesis/visual-editor` | 1 |
| `…/9615031-filter-data-automation-action` | `/learn/automation/filter-data` | 1 |
| `…/9494976-webhooks-automation-trigger` | `/learn/automation/webhook-trigger` | 1 |
| `…/9711589-ai-forms-automation-trigger` | `/learn/automation/forms-trigger` | 1 |
| `…/9805047-branch-automation-action` | `/learn/automation/branch-action` | 1 |
| `…/10351362-loop-automation-action` | `/learn/automation/loop-action` | 1 |

¹ help.taskade.com itself now 301-redirects `taskade-ai-credits` → `taskade-ai-usage`, confirming `/learn/agents/ai-usage`.

### Safety
- Applied longest-source-first so the `custom-ai-agents` / `…-intelligence-pillar` prefix overlap can't corrupt — verified **0 malformed `/learn` URLs**.
- Post-migration scan: **0** non-archive `help.taskade.com/en/(articles|collections)` links remain.
- Fixed one bare-URL-as-link-text link + stale "help center" copy on the inbound-webhooks page.
- The 5 home-page "Platform Capabilities" learn-more links (the originally-reported ones) now all point to `/learn`.

🤖 Generated with [Claude Code](https://claude.ai/code)
