### PR TITLE
docs: curl + Python API examples, fix limits TBD, changelog stub

### DIFF
--- a/apis-living-system-development/sdk-quickstart.md
+++ b/apis-living-system-development/sdk-quickstart.md
@@ -64,12 +64,12 @@ async function taskade(operation: string, body: unknown) {
 const { items } = await taskade("listSpaces", {});
 ```
 
-## curl & Python
+## cURL & Python
 
 {% tabs %}
-{% tab title="curl" %}
+{% tab title="cURL" %}
 ```bash
-export TASKADE_TOKEN=your_api_token_placeholder
+export TASKADE_TOKEN=YOUR_TOKEN
 
 # List your projects (REST API v1)
 curl -s \
@@ -80,7 +80,7 @@ curl -s \
 curl -s -X POST \
   -H "Authorization: Bearer $TASKADE_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"spaceId":"your_space_id","agentId":"your_agent_id","prompt":"Summarize standup notes"}' \
+  -d '{"spaceId":"SPACE_ID","agentId":"AGENT_ID","prompt":"Summarize standup notes"}' \
   "https://www.taskade.com/api/v2/promptAgent"
 ```
 {% endtab %}
@@ -104,8 +104,8 @@ result = requests.post(
     "https://www.taskade.com/api/v2/promptAgent",
     headers=headers,
     json={
-        "spaceId": "your_space_id",
-        "agentId": "your_agent_id",
+        "spaceId": "SPACE_ID",
+        "agentId": "AGENT_ID",
         "prompt": "Summarize standup notes",
     },
 ).json()

--- a/apis-living-system-development/sdk-quickstart.md
+++ b/apis-living-system-development/sdk-quickstart.md
@@ -64,6 +64,55 @@ async function taskade(operation: string, body: unknown) {
 const { items } = await taskade("listSpaces", {});
 ```
 
+## curl & Python
+
+{% tabs %}
+{% tab title="curl" %}
+```bash
+export TASKADE_TOKEN=your_api_token_placeholder
+
+# List your projects (REST API v1)
+curl -s \
+  -H "Authorization: Bearer $TASKADE_TOKEN" \
+  "https://www.taskade.com/api/v1/me/projects"
+
+# Prompt an agent (Action API v2)
+curl -s -X POST \
+  -H "Authorization: Bearer $TASKADE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"spaceId":"your_space_id","agentId":"your_agent_id","prompt":"Summarize standup notes"}' \
+  "https://www.taskade.com/api/v2/promptAgent"
+```
+{% endtab %}
+
+{% tab title="Python" %}
+```python
+import os
+import requests
+
+token = os.environ["TASKADE_TOKEN"]
+headers = {"Authorization": f"Bearer {token}"}
+
+# List your projects (REST API v1)
+items = requests.get(
+    "https://www.taskade.com/api/v1/me/projects",
+    headers=headers,
+).json()["items"]
+
+# Prompt an agent (Action API v2)
+result = requests.post(
+    "https://www.taskade.com/api/v2/promptAgent",
+    headers=headers,
+    json={
+        "spaceId": "your_space_id",
+        "agentId": "your_agent_id",
+        "prompt": "Summarize standup notes",
+    },
+).json()
+```
+{% endtab %}
+{% endtabs %}
+
 ## What the SDK will look like
 
 `@taskade/sdk` is a **generated client** for the [Action API v2](api-v2-reference.md). When it's published you'll construct an `HttpClient` (which carries your token) and a `TaskadePublicApi` instance whose methods map 1:1 to the v2 operations:

--- a/genesis-living-system-builder/genesis/how-genesis-works.md
+++ b/genesis-living-system-builder/genesis/how-genesis-works.md
@@ -217,7 +217,7 @@ Every Genesis workspace earns an **Intelligence Score** from 0–100, calculated
 | Projects (Memory) | 2 pts | 10 | 20 |
 | AI Agents (Intelligence) | 10 pts | 3 | 30 |
 | Automation Flows (Execution) | 5 pts | 6 | 30 |
-| Integrations (Connections) | _Reserved_ | _TBD_ | 20 |
+| Integrations (Connections) | _Reserved_ | — | 20 |
 | **Total** | | | **100** |
 
 ### Intelligence Tiers

--- a/updates-and-timeline/changelog-2026/README.md
+++ b/updates-and-timeline/changelog-2026/README.md
@@ -1,2 +1,3 @@
 # Changelog (2026)
 
+Product updates, new features, and improvements shipped in 2026. For releases before 2026, see the [Changelog archive](../../changelog/).

--- a/updates-and-timeline/changelog-2026/README.md
+++ b/updates-and-timeline/changelog-2026/README.md
@@ -1,3 +1,3 @@
 # Changelog (2026)
 
-Product updates, new features, and improvements shipped in 2026. For releases before 2026, see the [Changelog archive](../../changelog/).
+Product updates, new features, and improvements shipped in 2026. For releases before 2026, see the [Changelog archive](../../changelog/README.md).


### PR DESCRIPTION
## Summary

- **sdk-quickstart.md** — adds `curl` and `Python` tabs alongside the existing TypeScript section; covers REST v1 (list projects) and Action v2 (prompt agent). Directly addresses the missing-language gap in [#45](https://github.com/taskade/docs/issues/45).
- **how-genesis-works.md** — replaces literal `_TBD_` with `—` in the Intelligence Score table (Integrations row is Reserved/not yet scored).
- **changelog-2026/README.md** — adds a one-line intro + archive link to what was a heading-only stub (live page in the GitBook nav).

## Test plan

- [ ] Verify `sdk-quickstart` renders both new tabs on docs.taskade.com
- [ ] Confirm Intelligence Score table no longer shows `_TBD_`
- [ ] Confirm Changelog 2026 index shows the intro line