### PR TITLE
chore(repo): add .github issue + PR templates for contributors

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 📚 Browse the docs
+    url: https://docs.taskade.com
+    about: Search the live documentation first — your answer may already be there.
+  - name: 💬 Ask a question (Discussions)
+    url: https://github.com/taskade/docs/discussions
+    about: Questions, ideas, and general help for building on Taskade.
+  - name: 🌐 Taskade Community
+    url: https://www.taskade.com/community
+    about: Share apps, templates, and workflows with other builders.
+  - name: 🔑 Developer Portal
+    url: https://docs.taskade.com/apis-and-developer/developer-home
+    about: API, SDK, and MCP reference for building on Taskade.

--- a/.github/ISSUE_TEMPLATE/content-request.yml
+++ b/.github/ISSUE_TEMPLATE/content-request.yml
@@ -1,0 +1,22 @@
+name: 💡 Content request
+description: Request new documentation or expanded coverage
+title: "[Request]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: topic
+    attributes:
+      label: What should we document?
+      description: The feature, endpoint, or workflow you'd like covered.
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why is this useful?
+      description: What are you trying to build, and what's missing today?
+  - type: input
+    id: refs
+    attributes:
+      label: Related links
+      description: Existing pages, API endpoints, or product features (optional).

--- a/.github/ISSUE_TEMPLATE/documentation-issue.yml
+++ b/.github/ISSUE_TEMPLATE/documentation-issue.yml
@@ -1,0 +1,42 @@
+name: 📝 Documentation issue
+description: Report something incorrect, outdated, or confusing in the docs
+title: "[Docs]: "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve the Taskade docs! For a typo or small fix, you can also edit the page directly on GitHub and open a pull request.
+  - type: input
+    id: page
+    attributes:
+      label: Page URL or file path
+      description: The docs.taskade.com page (or repo file) with the issue.
+      placeholder: https://docs.taskade.com/apis-and-developer/sdk-quickstart
+    validations:
+      required: true
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type of issue
+      options:
+        - Incorrect / inaccurate
+        - Outdated
+        - Confusing / unclear
+        - Broken link or image
+        - Typo / formatting
+        - Missing information
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's wrong?
+      description: What is incorrect, outdated, or unclear?
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What should it say?
+      description: The correct or clearer version, if you know it.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+<!-- Thanks for contributing to the Taskade docs! -->
+
+## What does this PR change?
+
+<!-- Brief description of the docs change. Link any related issue (e.g. Closes #123). -->
+
+## Checklist
+
+- [ ] No secrets, API keys, tokens, or `.env` files — this is a **public** repo (see [SECURITY.md](../SECURITY.md))
+- [ ] Code examples use placeholder values (e.g. `your_api_token_placeholder`)
+- [ ] Internal links use **relative paths** (e.g. `genesis-living-system-builder/...`)
+- [ ] `SUMMARY.md` updated if pages were added, removed, or renamed
+- [ ] GitBook syntax left intact (`{% hint %}`, `{% tabs %}`, `<figure>`, card tables)
+- [ ] Previewed the change (locally or on docs.taskade.com after merge)


### PR DESCRIPTION
## Summary

Adds a contributor funnel to `taskade/docs` (none existed before). All files live under `.github/`, which the SUMMARY-driven GitBook site ignores — **zero risk to docs.taskade.com**.

### Added
- `.github/ISSUE_TEMPLATE/documentation-issue.yml` — report incorrect / outdated / unclear / broken docs (structured form)
- `.github/ISSUE_TEMPLATE/content-request.yml` — request new or expanded coverage
- `.github/ISSUE_TEMPLATE/config.yml` — contact links to the live docs, Discussions, Community, and Developer Portal
- `.github/PULL_REQUEST_TEMPLATE.md` — checklist mirroring `contributing.md` / `CLAUDE.md` (no secrets, placeholder values, relative links, `SUMMARY.md` updated, GitBook syntax intact)

### Intentionally NOT included (need a maintainer decision)
- **LICENSE** — a docs license is a legal choice. Recommendation: **CC BY 4.0** for the prose content (or MIT if you want code samples freely reusable). Say the word and I'll add it.
- **CODE_OF_CONDUCT.md** — standard Contributor Covenant needs a contact method; there's no dedicated public conduct/security email in `SECURITY.md` to reuse. Tell me the contact and I'll add it.

These pair with the repo metadata just shipped (description, 16 topics, Discussions enabled) and the README visuals in #70.