### PR TITLE
docs(genesis): automation/API accuracy + App Secrets page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ PENDING_CHANGES_REVIEW.md
 *.pem
 *credentials*
 *secrets*
+# Exception: a public docs PAGE about the App Secrets feature (no real secrets in it)
+!genesis-living-system-builder/space-apps-guide/app-secrets.md
 config/local.json
 config/production.json
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -109,6 +109,7 @@
   * [Prompt Library](genesis-living-system-builder/space-apps-guide/genesis-prompt-library.md)
   * [Advanced Features](genesis-living-system-builder/space-apps-guide/advanced-features.md)
   * [Custom Domains & Branding](genesis-living-system-builder/space-apps-guide/custom-domains.md)
+  * [App Secrets & External API Calls](genesis-living-system-builder/space-apps-guide/app-secrets.md)
 
 ## AI Features
 

--- a/genesis-living-system-builder/automation/README.md
+++ b/genesis-living-system-builder/automation/README.md
@@ -70,12 +70,16 @@ Use an agent to classify, extract, or draft. Then route or act on the structured
 * **Custom Field Updated** — when a custom field value changes
 * **Project Completed** — when all tasks are done
 * **Public Agent Chat Ended** — when a public agent conversation finishes
+* **Task Moved** — when a task moves from one project to another
+* **Project Created** — when a new project is created in a space
+* **Due Date Removed** — when a due date is cleared from a task
+* **File Added to Media** — when a file is uploaded to the media library
 
 **External Triggers:**
 
 * **Webhook** — receive data from any external service via HTTP POST
 * **Form** — custom input forms with text, email, date, and time fields
-* **Schedule** — run hourly, daily, weekly, or monthly
+* **Schedule** — run every X minutes (sub-hourly intervals), hourly, daily, weekly, or monthly
 * **Mailhook** — trigger from incoming emails
 
 **Integration Triggers** (from connected services):

--- a/genesis-living-system-builder/automation/actions.md
+++ b/genesis-living-system-builder/automation/actions.md
@@ -30,6 +30,10 @@ Actions can be chained together to create complex multi-step workflows, with con
 | **Add Knowledge to Agent**           | Transcribes knowledge and adds it as knowledge to an agent | Agent training, content integration              | `agentId`, `content`, `source`                         |
 | **Add Project to Agent Knowledge**   | Automatically trains your AI agents with project content   | Agent enhancement, knowledge management          | `agentId`, `projectId`, `scope`                        |
 | **Ask Agent With Structured Output** | Structures the output of agent replies                     | Standardized AI responses                        | `agentId`, `query`, `outputFormat`                     |
+| **task.addComment**                  | Appends a comment to an existing task node                 | Audit trails, team communication on tasks        | `taskId`, `comment`                                    |
+| **task.update**                      | Updates a task node's content or note field                | Inline edits, AI-driven content rewrites         | `taskId`, `content`, `note`                            |
+| **task.get**                         | Reads a task node and returns its current data             | Conditional logic, data-driven downstream steps  | `taskId`                                               |
+| **project.getInfo**                  | Reads project metadata (name, dates, member list, etc.)    | Dynamic references to project context in flows   | `projectId`                                            |
 
 ### Data Processing & Integration Actions
 
@@ -50,6 +54,7 @@ Actions can be chained together to create complex multi-step workflows, with con
 | **Filter Data**               | Performs actions only when the data meets a certain condition                 | Conditional processing, data validation | `condition`, `dataSource`, `filterCriteria`     |
 | **Branch**                    | Creates different paths within your workflow, depending on certain conditions | Decision trees, conditional logic       | `condition`, `truePath`, `falsePath`            |
 | **Transform Array to String** | Converts the output of Find Task(s) and Find Row(s) actions into text         | Data formatting, reporting              | `arrayInput`, `template`, `separator`           |
+| **flow.run**                  | Runs a saved flow as a depth-guarded subflow (prevents infinite recursion)    | Reusable sub-flows, modular automation  | `flowId`, `input`, `maxDepth`                   |
 
 ### Advanced Actions
 
@@ -195,8 +200,6 @@ Find Tasks → Transform Array → Export to CSV
 
 ***
 
-\| **Transform Array to String** | Converts task arrays into readable text | `array`, `separator`, `format` | Convert task list to comma-separated string |
-
 ### Custom Fields Automation Settings
 
 {% hint style="info" %}
@@ -242,10 +245,16 @@ The Update Custom Fields action allows you to automatically update custom fields
 | **Ask Agent With Structured Output** | Structures the output of agent replies              | `agentId`, `query`, `outputSchema` | Get JSON response with specific fields              |
 | **Add Project to Agent Knowledge**   | Automatically trains AI agents with project content | `agentId`, `projectId`             | Keep agents updated with latest project information |
 
+{% hint style="info" %}
+**Genesis self-assembly capability:** Flows can programmatically assemble and configure agents at runtime — this is the mechanism that powers Genesis self-assembly features. If you are building advanced Genesis flows, check the in-app action picker for current availability of agent-assembly steps; the exact surface exposed to automation builders may vary by plan.
+{% endhint %}
+
 ### Ask Agent With Structured Output Settings
 
 {% hint style="info" %}
 The Ask Agent With Structured Output action extracts specific information from AI agent responses and formats it as structured data that can be used as variables in subsequent automation steps.
+
+**BYOK support:** When a Bring Your Own Key (BYOK) model is configured on the target agent, the one-shot structured-output path honors that key, so inference runs against your own API account rather than Taskade's shared quota.
 {% endhint %}
 
 #### When to Use Structured Output
@@ -309,7 +318,9 @@ The Ask Agent With Structured Output action extracts specific information from A
 
 ***
 
-\| **Prompt AI** | Give the model detailed instructions | `prompt`, `systemMessage`, `temperature` | Custom AI processing with specific instructions | | **Add Knowledge to Agent** | Transcribes knowledge and adds it to an agent | `agentId`, `content`, `source` | Train agent with new documentation | | **Add Project to Agent Knowledge** | Automatically trains AI agents with project content | `agentId`, `projectId`, `includeCompleted` | Add project data to agent's knowledge base |
+| Action          | Description                          | Parameters                               | Example                                              |
+| --------------- | ------------------------------------ | ---------------------------------------- | ---------------------------------------------------- |
+| **Prompt AI**   | Give the model detailed instructions | `prompt`, `systemMessage`, `temperature` | Custom AI processing with specific instructions      |
 
 ### Add Project to Agent Knowledge Automation Settings
 
@@ -692,7 +703,9 @@ YouTube Video → Transcribe → Generate Quiz → Create Study Guide → Add to
 
 ***
 
-\| **Convert File to Text** | Convert a source file into text | `fileUrl`, `fileType`, `extractImages` | Convert PDF manual to searchable text | | **Generate Image with DALL·E 3** | Create images from text prompts using OpenAI | `prompt`, `size`, `style`, `quality` | Generate illustrations and visual content | | **Upload File to Media** | Upload file through URL to workspace media | `fileUrl`, `fileName`, `folderId` | Save document to project media library | | **Send HTTP Request** | Makes an API request to an endpoint with multipart file support | `method`, `url`, `headers`, `body`, `files` | Call external API with file attachments |
+| Action                            | Description                                  | Parameters                        | Example                                   |
+| --------------------------------- | -------------------------------------------- | --------------------------------- | ----------------------------------------- |
+| **Generate Image with DALL·E 3**  | Create images from text prompts using OpenAI | `prompt`, `size`, `style`, `quality` | Generate illustrations and visual content |
 
 ### HTTP Request Automation Settings
 
@@ -762,6 +775,18 @@ The Generate Image with DALL·E 3 action creates beautiful images from text prom
 * Include artistic references (e.g., "in the style of Picasso")
 * Specify image format and intended use
 * Use descriptive adjectives for better results
+
+### Genesis — Image Format Conversion
+
+{% hint style="info" %}
+The **Image Format Conversion** action (available in Genesis flows) converts an image from one format to another entirely within Taskade — no external service required. Useful for normalizing images before uploading them to downstream steps.
+{% endhint %}
+
+| Action                       | Description                                              | Parameters                          | Example                                     |
+| ---------------------------- | -------------------------------------------------------- | ----------------------------------- | ------------------------------------------- |
+| **Image Format Conversion**  | Converts an image file to a target format (e.g., PNG → JPEG, WebP, etc.) | `imageUrl`, `targetFormat`, `quality` | Convert an uploaded PNG to WebP before storing |
+
+Supported target formats include common raster types (JPEG, PNG, WebP, and more). Output is returned as a file reference that can be passed to subsequent actions such as **Upload File to Media**.
 
 ### Categorize with AI Automation Settings
 
@@ -902,8 +927,6 @@ Branch: If "Safe" → Publish Immediately
 
 ***
 
-\| **Search Web** | Searches the web for information | `query`, `maxResults`, `safeSearch` | Research topic for content creation |
-
 ### Search Web Automation Settings
 
 {% hint style="info" %}
@@ -1012,8 +1035,6 @@ Result: Proactive competitive intelligence
 
 ***
 
-\| **Filter Data** | Performs actions only when data meets conditions | `data`, `condition`, `operator` | Process only high-priority tickets | | **Loop** | Iterates through data for batch processing | `array`, `actions`, `maxIterations` | Process multiple form submissions | | **Branch** | Creates different workflow paths based on conditions | `condition`, `trueActions`, `falseActions` | Route tickets based on urgency level |
-
 ## Communication Actions
 
 ### Slack
@@ -1045,6 +1066,18 @@ Result: Proactive competitive intelligence
 | `discord.createRole`   | Creates new role         | `guildId`, `name`, `permissions`  | Create "Beta Tester" role       |
 | `discord.assignRole`   | Assigns role to user     | `guildId`, `userId`, `roleId`     | Grant access to private channel |
 | `discord.createInvite` | Creates invite link      | `channelId`, `maxUses`, `expires` | Generate one-time invite        |
+
+### Notify by Email (Native)
+
+{% hint style="success" %}
+Taskade includes a built-in **Notify by Email** action that sends transactional notifications through Taskade's own mail infrastructure. No OAuth connection or third-party email provider is required.
+{% endhint %}
+
+| Action                    | Description                                                       | Parameters                                  | Example                                     |
+| ------------------------- | ----------------------------------------------------------------- | ------------------------------------------- | ------------------------------------------- |
+| **Notify by Email**       | Sends a notification email via Taskade (no OAuth required)        | `to`, `subject`, `body`                     | Alert a stakeholder when a task is created  |
+
+This action is distinct from the `email.send` integration rows above, which require an external mail provider connection.
 
 ## Data & CRM Actions
 
@@ -1146,13 +1179,16 @@ Result: Proactive competitive intelligence
 
 ### Data Processing
 
-| Action           | Description              | Parameters                         | Example                  |
-| ---------------- | ------------------------ | ---------------------------------- | ------------------------ |
-| `data.transform` | Transforms data format   | `input`, `mapping`, `outputFormat` | Convert CSV to JSON      |
-| `data.validate`  | Validates data schema    | `input`, `schema`                  | Check required fields    |
-| `data.merge`     | Merges data objects      | `objects`, `mergeStrategy`         | Combine multiple sources |
-| `data.filter`    | Filters data by criteria | `input`, `conditions`              | Remove invalid entries   |
-| `data.aggregate` | Aggregates data          | `input`, `groupBy`, `functions`    | Calculate totals         |
+| Action              | Description                                                      | Parameters                         | Example                             |
+| ------------------- | ---------------------------------------------------------------- | ---------------------------------- | ----------------------------------- |
+| `data.transform`    | Transforms data format                                           | `input`, `mapping`, `outputFormat` | Convert CSV to JSON                 |
+| `data.validate`     | Validates data schema                                            | `input`, `schema`                  | Check required fields               |
+| `data.merge`        | Merges data objects                                              | `objects`, `mergeStrategy`         | Combine multiple sources            |
+| `data.filter`       | Filters data by criteria                                         | `input`, `conditions`              | Remove invalid entries              |
+| `data.aggregate`    | Aggregates data                                                  | `input`, `groupBy`, `functions`    | Calculate totals                    |
+| **split**           | Splits a text string into an array on a delimiter               | `text`, `delimiter`                | Split CSV line into fields          |
+| **trim**            | Removes leading and trailing whitespace from a text string      | `text`                             | Clean user-submitted input          |
+| **convertCase**     | Converts text case (uppercase, lowercase, titleCase, camelCase) | `text`, `targetCase`               | Normalize status labels to lowercase |
 
 ### File Operations
 

--- a/genesis-living-system-builder/automation/ai-forms.md
+++ b/genesis-living-system-builder/automation/ai-forms.md
@@ -436,36 +436,9 @@ function ContactPage() {
 
 ### **API Access**
 
-#### **Form Data API**
+#### **Form Data**
 
-```bash
-# Get form submissions with AI analysis
-curl -X GET "https://api.taskade.com/v1/forms/your-form-id/submissions" \
-  -H "Authorization: Bearer YOUR_TOKEN" \
-  -H "Content-Type: application/json"
-```
-
-```json
-{
-  "submissions": [
-    {
-      "id": "submission_123",
-      "timestamp": "2024-01-15T10:30:00Z",
-      "data": {
-        "name": "John Smith",
-        "email": "john@example.com",
-        "feedback": "Great service, very satisfied!"
-      },
-      "aiAnalysis": {
-        "sentiment": 0.85,
-        "categories": ["compliment", "satisfaction"],
-        "priority": "low",
-        "suggestedActions": ["send_thank_you", "add_to_testimonials"]
-      }
-    }
-  ]
-}
-```
+AI Forms does not currently expose a public REST API for reading submissions in API v1 (there is no `/forms` endpoint). To work with submission data programmatically, capture it with an **automation** when a form is submitted — route responses into a project, forward them to an external service via the HTTP/Webhook action, or hand them to an agent. See [Webhooks](../../apis-living-system-development/webhooks.md) and the [Action & Trigger Reference](./actions.md).
 
 ### **Webhook Integration**
 

--- a/genesis-living-system-builder/automation/integrations.md
+++ b/genesis-living-system-builder/automation/integrations.md
@@ -25,12 +25,13 @@ Taskade connects to **100+ tools and services** across communication, productivi
 | Service | Triggers | Actions | Authentication |
 |---------|----------|---------|----------------|
 | **Slack** | New message, mention, reaction | Send message, create channel, update status, invite user | OAuth 2.0 |
-| **Microsoft Teams** | New message, meeting scheduled | Post message, create meeting, manage channels | OAuth 2.0 |
+| **Microsoft Teams** | New message, new channel message, meeting scheduled | Post message, create meeting, manage channels | OAuth 2.0 |
+| **Microsoft Outlook** | New email received | Send email, reply to email, forward email, move email, get email, find email, mark as read | OAuth 2.0 |
 | **Discord** | New message, member joined | Send message, manage roles, create invite | Bot Token |
 | **WhatsApp Business** | New message received | Send message, send template | API Key |
 | **Telegram** | New message, command | Send message, create poll, manage chat | Bot Token |
 | **Email (SMTP)** | New email received | Send email, create campaign | SMTP Credentials |
-| **Gmail** | New email, label added | Send email, create draft, add label | OAuth 2.0 |
+| **Gmail** | New email, label added (including label-filtered), new email matching filter | Send email, reply to email, get email, create draft, add label | OAuth 2.0 |
 
 ### 🛠️ Development & Project Management
 
@@ -41,17 +42,23 @@ Taskade connects to **100+ tools and services** across communication, productivi
 | **Jira** | Issue created, status changed | Create ticket, update status, assign user | OAuth 2.0 / API Key |
 | **Linear** | Issue created, updated | Create issue, update priority, assign | OAuth 2.0 / API Key |
 | **Asana** | Task created, completed | Create task, update project, assign | OAuth 2.0 / PAT |
-| **Trello** | Card created, moved | Create card, move card, add member | OAuth 2.0 / API Key |
+| **ClickUp** | Task created, task status changed | Create task, update task, delete task, add comment, get task, list tasks, find task by name, get task comments | OAuth 2.0 / API Key |
+| **Google Tasks** | Task created, task completed | Create task, update task, delete task, complete task, list tasks, clear completed, get task, find task | OAuth 2.0 |
 | **Monday.com** | Item created, updated | Create item, update status, notify | OAuth 2.0 / API Key |
+| **Todoist** | Task completed | Create task, update task, complete task, delete task, find task | OAuth 2.0 / API Key |
+| **Trello** | Card created, moved | Create card, move card, add member | OAuth 2.0 / API Key |
 
 ### 📊 Data & Analytics
 
 | Service | Triggers | Actions | Authentication |
 |---------|----------|---------|----------------|
-| **Google Sheets** | New row, cell updated | Add row, update cell, create chart | OAuth 2.0 |
+| **Google Sheets** | New row, row updated, cell updated | Add row, update cell, create chart, create spreadsheet | OAuth 2.0 |
 | **Airtable** | New record, updated | Create record, update field, link records | OAuth 2.0 / API Key |
+| **Google Docs** | New document created | Read document, edit template file | OAuth 2.0 |
+| **Google Drive** | New file, file updated | Upload file, create folder, move file, share file, delete file (Shared Drive supported) | OAuth 2.0 |
+| **Google Calendar** | Event created, event started | Create event, update event, list events (with search), delete event, add attendee | OAuth 2.0 |
 | **Notion** | Page created, updated | Create page, update database, add content | OAuth 2.0 |
-| **HubSpot** | Contact created, deal updated | Create contact, update deal, send email | OAuth 2.0 / API Key |
+| **HubSpot** | Contact created, deal updated | Create contact, upsert contact, search contacts, get contact, update contact, create deal, update deal, search deals, get deal, send email | OAuth 2.0 / API Key |
 | **Salesforce** | Lead created, opportunity updated | Create lead, update opportunity, assign | OAuth 2.0 |
 | **Pipedrive** | Deal created, activity added | Create deal, add activity, update stage | OAuth 2.0 / API Key |
 | **Custom Webhooks** | Webhook received | Send HTTP request, trigger workflow | API Key / Bearer Token |
@@ -72,7 +79,8 @@ Taskade connects to **100+ tools and services** across communication, productivi
 
 | Service | Triggers | Actions | Authentication |
 |---------|----------|---------|----------------|
-| **WordPress** | Post published, comment added | Create post, update content, moderate comment | OAuth 2.0 / API Key |
+| **Twitter/X** | Mention detected | Post tweet, reply to tweet, delete post, retweet, post tweet with image attachment | OAuth 2.0 |
+| **WordPress** | New post published, comment added | Create post with featured image, update content, moderate comment | OAuth 2.0 / API Key |
 | **Webflow** | Form submitted, item published | Create CMS item, update content, publish | OAuth 2.0 / API Key |
 | **Typeform** | Form submitted, response updated | Create form, update response, send email | OAuth 2.0 / PAT |
 | **Google Forms** | Form submitted | Create form, add response, send notification | OAuth 2.0 |

--- a/genesis-living-system-builder/community-and-sharing/README.md
+++ b/genesis-living-system-builder/community-and-sharing/README.md
@@ -546,13 +546,7 @@ Some community apps include embeddable components:
 
 ### API Integration with Community Apps
 
-Community apps can include API endpoints for integration:
-
-```javascript
-// Connect to a community app's API
-const response = await fetch('https://api.taskade.com/community/app/xyz/data');
-const communityData = await response.json();
-```
+Apps you clone from the community are standard Genesis apps. Build integrations with the [public API](../../apis-living-system-development/developer-home.md), and have an app call external services securely through the [App Secrets](../space-apps-guide/app-secrets.md) outbound proxy — there is no separate `community` API surface.
 
 ### Collaborative Development
 

--- a/genesis-living-system-builder/community-and-sharing/publish-and-clone.md
+++ b/genesis-living-system-builder/community-and-sharing/publish-and-clone.md
@@ -11,8 +11,13 @@
 - [Password Protection](#password-protection)
 - [Publish to Community Gallery](#publish-to-community-gallery)
 - [Clone and Remix Apps](#clone-and-remix-apps)
+- [Paid Apps](#paid-apps)
 - [Custom Domains](#custom-domains)
 - [Advanced Sharing Options](#advanced-sharing-options)
+- [Embedding Your App](#embedding-your-app)
+- [SEO Customization](#seo-customization)
+- [White-Label Branding](#white-label-branding)
+- [Enterprise SSO (OIDC)](#enterprise-sso-oidc)
 - [Security Considerations](#security-considerations)
 - [Sharing Methods at a Glance](#sharing-methods-at-a-glance)
 - [What's Next](#whats-next)
@@ -139,6 +144,34 @@ Any public or shared app can be cloned:
 
 ---
 
+## Paid Apps
+
+Genesis lets creators monetize their apps directly. When you enable monetization for an app, buyers pay via Stripe before receiving their own private copy.
+
+### How It Works
+
+| Step | What Happens |
+|---|---|
+| **Creator sets a price** | In the app's **Publish** settings, open the **Monetization** panel and set a price for the app. |
+| **Buyer discovers the app** | The app appears in the Community Gallery (or via a direct link) with a price tag. |
+| **Buyer pays via Stripe** | Checkout is handled by Stripe. No payment details are stored by Taskade. |
+| **Buyer receives a private copy** | After successful payment, Taskade clones the app directly into the buyer's workspace. |
+
+### Key Rules for Paid App Copies
+
+| Rule | Detail |
+|---|---|
+| **Scope** | Cloned paid apps are scoped to the buyer's workspace only. |
+| **Re-sharing** | Buyers cannot re-publish or redistribute paid app copies to other users. |
+| **Clone ancestry** | Taskade tracks clone lineage — each paid copy is linked to the original app and its creator. |
+| **No revenue figures here** | Payout terms and percentages are shown in your Monetization dashboard, not documented here — they may change. |
+
+{% hint style="info" %}
+Paid apps do not affect the buyer's ability to customize or extend the app within their own workspace. Re-sharing and re-selling the cloned copy is blocked to protect creator rights.
+{% endhint %}
+
+---
+
 ## Custom Domains
 
 Connect your own domain to any published Genesis app:
@@ -174,6 +207,94 @@ Connect your own domain to any published Genesis app:
 
 ---
 
+## Embedding Your App
+
+You can embed any published Genesis app into an external website, blog, or documentation page using an iframe.
+
+### Getting the Embed Code
+
+1. Open your published app.
+2. Click the **Share** menu (top-right of the app toolbar).
+3. Select **Embed** to reveal the embed code snippet.
+4. Copy the `<iframe>` tag and paste it into your page's HTML.
+
+### Recommended iframe Attributes
+
+```html
+<iframe
+  src="https://your-app-url.taskade.com"
+  width="100%"
+  style="min-height: 600px; border: none;"
+  allowfullscreen
+></iframe>
+```
+
+| Attribute | Recommended Value | Why |
+|---|---|---|
+| `width` | `100%` | Fills the container responsively |
+| `min-height` | `600px` (adjust to content) | Prevents the frame from collapsing |
+| `border` | `none` | Removes the default iframe border |
+| `allowfullscreen` | present | Allows modal/fullscreen views inside the app |
+
+{% hint style="info" %}
+If your embedding site enforces a `Content-Security-Policy` with `frame-ancestors`, you must add `taskade.com` (or your custom domain) to the allowed-origin list. Frames blocked by CSP will show a blank panel with no error visible to the end user.
+{% endhint %}
+
+---
+
+## SEO Customization
+
+Genesis apps support custom search-engine and social metadata so your published app is discoverable and looks polished when shared.
+
+### How to Set SEO Fields
+
+1. Open your app's **Publish** settings.
+2. Locate the **SEO** panel.
+3. Fill in the fields described below.
+4. Save and republish (or let Auto-publish apply the change).
+
+| Field | What It Controls | Tips |
+|---|---|---|
+| **Meta title** | The `<title>` tag and browser tab label | Keep under ~60 characters to avoid truncation in search results |
+| **Meta description** | The snippet shown in search results | Aim for ~150 characters; describe what the app does and who it's for |
+| **Open Graph image** | The preview image on social shares (LinkedIn, X/Twitter, Slack, etc.) | Recommended size 1200 × 630 px; upload via the OG Image field |
+
+{% hint style="info" %}
+The Open Graph image you upload is stored in your workspace assets. If you later delete the asset, the social preview will fall back to the Taskade default image.
+{% endhint %}
+
+---
+
+## White-Label Branding
+
+Business+ workspaces can strip or replace Taskade's default branding on published apps.
+
+### How to Configure White-Label Options
+
+1. Open your app's **Publish** settings.
+2. Navigate to the **Branding** panel.
+3. Apply the options below and save.
+
+| Option | What It Does |
+|---|---|
+| **Watermark toggle** | Hides the "Powered by Taskade" badge from the published app footer |
+| **Favicon upload** | Replaces the default Taskade favicon with your own `.ico` or `.png` file |
+| **Color theme** | Sets primary and accent colors for the app chrome to match your brand palette |
+
+{% hint style="info" %}
+White-label settings apply to the published view only. The Taskade editor interface retains standard Taskade branding for workspace members.
+{% endhint %}
+
+---
+
+## Enterprise SSO (OIDC)
+
+Enterprise workspaces can gate app access behind your organization's Identity Provider (IdP) using OpenID Connect (OIDC). This means visitors must sign in through your corporate SSO before they can view or interact with the app.
+
+Contact sales to enable OIDC for your workspace — setup guidance is provided during Enterprise onboarding.
+
+---
+
 ## Security Considerations
 
 | Practice | Recommendation |
@@ -196,6 +317,7 @@ Connect your own domain to any published Genesis app:
 | **Secret link** | Link holders | Yes | Business+ | Optional | Yes | Client portals, partners |
 | **Private** | Workspace only | N/A | Business+ | Optional | Yes | Internal tools |
 | **Embed** | Website visitors | No | N/A | Optional | Yes | Blog, documentation |
+| **Paid** | Anyone (after purchase) | Yes (paid copy) | Business+ | Optional | Yes | Monetized templates, premium apps — buyer receives a private copy in their own workspace |
 
 ---
 

--- a/genesis-living-system-builder/genesis/README.md
+++ b/genesis-living-system-builder/genesis/README.md
@@ -73,3 +73,7 @@ Start here:
 * [Living Motion Overview](../automation/)
 * [Integration Options](../automation/integrations.md)
 * [Action & Trigger Reference](../automation/actions.md)
+
+### What's next
+
+Edit your app's source from Claude, Cursor, or any IDE via [Genesis App MCP (Beta)](../../apis-living-system-development/genesis-app-mcp.md).

--- a/genesis-living-system-builder/genesis/getting-started.md
+++ b/genesis-living-system-builder/genesis/getting-started.md
@@ -258,12 +258,17 @@ Need adjustments? Genesis makes changes instantly through conversation.
 
 Your app is ready for the real world! You've built something that solves a real business problem, and now it's time to put it in front of actual users.
 
+{% hint style="warning" %}
+**Secure your API keys before publishing.** If your app calls external APIs, store credentials in the Secrets vault (space **Settings → Secrets**) and route calls through the outbound proxy so keys never ship in client code. Genesis blocks publish if hardcoded secrets are detected. See [App Secrets](../space-apps-guide/app-secrets.md) for setup steps.
+{% endhint %}
+
 ### **Publishing Options**
 
 1. **Private Use**: Keep it within your workspace for team use
 2. **Custom Domain**: Publish under your branded domain (e.g., `app.yourcompany.com`)
 3. **Share with Community**: Publish to the global Taskade marketplace for others to discover and fork
 4. **Public Link**: Get a shareable URL for external users
+5. **Genesis App MCP (Beta)**: Expose your app as an MCP server so AI agents and external tools can call it programmatically — see [Genesis App MCP (Beta)](../../apis-living-system-development/genesis-app-mcp.md)
 
 ### **Getting It Live**
 

--- a/genesis-living-system-builder/genesis/mcp-connectors.md
+++ b/genesis-living-system-builder/genesis/mcp-connectors.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Connect your Genesis apps and AI agents to 30+ external services using MCP
+  Connect your Genesis apps and AI agents to 31+ external services using MCP
   (Model Context Protocol) — the universal standard for AI tool integration.
 ---
 

--- a/genesis-living-system-builder/genesis/version-history.md
+++ b/genesis-living-system-builder/genesis/version-history.md
@@ -7,6 +7,7 @@
 - [Overview](#overview)
 - [What Is Tracked](#what-is-tracked)
 - [View App Versions](#view-app-versions)
+- [Inspect and Configure Your App](#inspect-and-configure-your-app)
 - [Restore a Previous Version](#restore-a-previous-version)
 - [Version History & Publishing](#version-history--publishing)
 - [Best Practices](#best-practices)
@@ -65,6 +66,26 @@ Each version entry shows:
 
 ---
 
+## Inspect and Configure Your App
+
+### Code View (Read-Only)
+
+Genesis includes a **Code View** tab inside the app editor. This tab gives you a read-only look at the source code Genesis has generated for your app — useful for understanding what was built, debugging unexpected behavior, or sharing context with a developer. The Code View is inspectable only; edits are made through the Genesis prompt interface, not by modifying the source directly.
+
+### Custom `<head>` HTML Injection
+
+Published Genesis apps support injecting custom HTML into the `<head>` of every page. Access this in your app's **Settings → Advanced**. Common uses include:
+
+- Adding analytics snippets (e.g., a tracking pixel or tag manager)
+- Loading custom fonts via a `<link>` tag
+- Including third-party scripts that must load early
+
+{% hint style="warning" %}
+Only add trusted, well-understood code here. Injected `<head>` markup runs on every page of your published app and affects all visitors.
+{% endhint %}
+
+---
+
 ## Restore a Previous Version
 
 | Step | Action |
@@ -92,6 +113,18 @@ How version history interacts with your publishing strategy:
 |---|---|
 | **Auto publish** | Every version is immediately live. Restoring a version instantly updates the published app. |
 | **Manual publish** | Versions accumulate in draft. Restoring a version updates the draft. You choose when to publish. |
+
+### Auto vs. Manual Publish
+
+Genesis lets you choose how versions reach your live app. The setting lives in your app's **Settings → Publish Strategy**.
+
+**Auto publish** (the default) pushes every save and every restored version directly to your published URL. This is convenient during early development but means any mistake — including a misfire restore — is immediately visible to users.
+
+**Manual publish** decouples iteration from release. Changes (including restored versions) stay in draft until you explicitly click **Publish**. For an app that already has live users, manual mode is the safer choice: you can restore, preview, and validate a version internally before anyone else sees it. A restore under manual publish updates the draft state only — the published app continues running whatever version was last deliberately published.
+
+{% hint style="info" %}
+Prefer **Manual** publish for any Genesis app in active use. It gives you a review gate between your Version History and your users, so a restore or experimental prompt never reaches production unintentionally.
+{% endhint %}
 
 ### Publish Status Indicators
 

--- a/genesis-living-system-builder/genesis/workspace-dna.md
+++ b/genesis-living-system-builder/genesis/workspace-dna.md
@@ -31,7 +31,7 @@ AI agents reason over your workspace context. They draft, classify, summarize, a
 - Multi-agent teams with automatic delegation
 - 22+ built-in tools (Slack, Gmail, Sheets, and more)
 - Persistent memory across conversations
-- Multiple AI models (GPT, Claude, Gemini)
+- Multiple frontier AI models (Claude Opus 4.8 / Fable-5, GPT-5.5, Gemini 3.5 Flash, Qwen 3.7, and more)
 
 **Learn more:** [AI Agents Getting Started](../ai-features/ai-agents-getting-started.md)
 
@@ -84,6 +84,23 @@ Your workspace has an Intelligence Score (0–100) that reflects its richness:
 | 81–100 | Genius | Full ecosystem — agents, automations, and data working as one |
 
 Higher scores mean Genesis can build better apps because it has more context to work with.
+
+## Workspace DNA Flow Canvas
+
+The Workspace DNA flow canvas is a visual, real-time relationship graph that surfaces from the workspace overview. It renders every project, agent, and automation as a node and draws live edges between them — showing at a glance how knowledge flows through your workspace.
+
+**What you see on the canvas:**
+
+- **Project nodes** — each database or project in Memory, with their current record count and connected agents
+- **Agent nodes** — every AI agent, the projects it reads, and the automations it triggers
+- **Automation nodes** — active workflows, their trigger sources, and the projects or agents they write back to
+- **Live edges** — directed connections that update in real time as events fire, records change, or agents respond
+
+**Phase 0 rollout:** The canvas is being introduced progressively starting from the workspace overview panel. Early access surfaces a read-only graph; later phases will add drag-to-rearrange layout, click-through to edit any node inline, and canvas-level filtering by node type or tag.
+
+{% hint style="info" %}
+**No setup required.** The canvas is generated automatically from your existing Workspace DNA — projects, agents, and automations you have already built appear as nodes the moment you open the view.
+{% endhint %}
 
 ## EVE: Your AI Companion
 

--- a/genesis-living-system-builder/space-apps-guide/app-secrets.md
+++ b/genesis-living-system-builder/space-apps-guide/app-secrets.md
@@ -1,0 +1,116 @@
+---
+description: >-
+  Store API keys and tokens in a per-space vault, then reference them safely in Genesis app code — real credentials never leave the server.
+---
+
+# App Secrets & External API Calls
+
+**Connect your Genesis app to third-party services — weather APIs, payment providers, CRMs, or any HTTP endpoint — without ever exposing credentials in your app's source code.**
+
+{% hint style="info" %}
+**App Secrets** are part of the Genesis app platform. Check your workspace plan for availability.
+{% endhint %}
+
+***
+
+## What Are App Secrets?
+
+App Secrets is a per-space credential vault found under **Settings → Secrets**. Each secret has two parts:
+
+- **Alias** — a short name you choose (e.g., `MY_API_KEY`, `STRIPE_SECRET`, `WEATHER_TOKEN`)
+- **Value** — the actual API key, token, or password
+
+Once saved, the value is encrypted at rest and is never returned to the browser. Your Genesis app code references secrets only by their alias — the real value is substituted server-side at request time.
+
+***
+
+## Adding a Secret
+
+1. Open your Space and navigate to **Settings → Secrets**.
+2. Click **Add Secret**.
+3. Enter an **Alias** (letters, numbers, and underscores; no spaces).
+4. Paste the **Value** (your API key or token).
+5. Click **Save**.
+
+The alias is now available to any code running inside that Genesis app.
+
+{% hint style="warning" %}
+Secret values are write-only after saving. To rotate a credential, delete the existing secret and add a new one with the same alias so your code references remain unchanged.
+{% endhint %}
+
+***
+
+## Calling External APIs Safely
+
+Genesis routes all outbound HTTP calls through a server-side proxy. When your app makes a request, the proxy scans the headers and body for `{{secret}}` placeholders and substitutes the real secret value (identified by the accompanying alias field) before the request leaves Taskade's infrastructure. The substituted value is never sent to the browser.
+
+### Conceptual example
+
+The following illustrates the placeholder pattern. This is not a specific SDK call — it shows the shape of what your Genesis app code would generate or reference when the proxy is configured.
+
+```javascript
+// CONCEPTUAL EXAMPLE — illustrates the {{secret}} substitution pattern
+// Genesis app code sends this request description to the proxy
+// Genesis routes this through its server-side proxy internally
+
+const response = await fetch(/* <Genesis-managed proxy endpoint> */, {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json"
+  },
+  body: JSON.stringify({
+    url: "https://api.example.com/v1/data",
+    method: "GET",
+    headers: {
+      // {{secret}} is the substitution token; which stored secret fills it
+      // is determined by a separate alias field, e.g. secretAlias: 'MY_API_KEY'
+      "Authorization": "Bearer {{secret}}"
+    },
+    secretAlias: "MY_API_KEY"
+  })
+});
+
+const data = await response.json();
+```
+
+At request time the proxy resolves `secretAlias` to the stored secret and replaces `{{secret}}` in the outbound request with the real credential value. The browser bundle only ever contains the alias string, not the credential itself.
+
+{% hint style="info" %}
+The exact proxy surface is managed by Genesis. You describe the integration you need in plain English and Genesis generates the appropriate outbound call — the `{{secret}}` substitution happens automatically, with the target secret selected via the alias you specify.
+{% endhint %}
+
+***
+
+## Security Model
+
+| Layer | What Taskade does |
+| ----- | ----------------- |
+| **Storage** | Secret values are encrypted at rest; the raw value is never returned to the client after saving |
+| **Substitution** | `{{secret}}` replacement happens server-side inside the proxy (the alias field selects which stored secret is used), never in the browser bundle |
+| **SSRF protection** | The proxy blocks requests to internal network ranges and loopback addresses (e.g., `169.254.x.x`, `10.x.x.x`, `127.0.0.1`); destination-host allowlisting is being rolled out |
+| **Response scrubbing** | Sensitive upstream response headers (e.g., `Set-Cookie` from the external API) are stripped before the response reaches your app |
+| **Audit scope** | Secret access is scoped to the space where the secret is defined; other spaces cannot reference it |
+
+***
+
+## Publish Guard
+
+Before Genesis publishes or deploys your app, it scans the app source for patterns that look like hardcoded credentials (long random strings in assignment statements, common key-prefix patterns, etc.).
+
+If a potential hardcoded secret is detected, **publishing is blocked** and Genesis surfaces a warning identifying the suspicious line. To resolve it:
+
+1. Move the credential to **Settings → Secrets** with an appropriate alias.
+2. Replace the hardcoded value in your source with `{{YOUR_ALIAS}}`.
+3. Re-publish.
+
+This guard runs on every publish attempt and cannot be bypassed — it is a safety rail, not an optional lint check.
+
+***
+
+## Best Practices
+
+- **Use descriptive aliases** — `SENDGRID_API_KEY` is clearer than `KEY1` when you return to the project later.
+- **One secret per credential** — avoid bundling multiple keys into a single secret value; granular secrets are easier to rotate.
+- **Rotate regularly** — update the secret value in the vault; your app code references the alias and picks up the new value immediately.
+- **Least privilege** — where the external API supports scoped tokens (read-only, single-resource, etc.), use the narrowest scope that your app requires.
+- **Never log secret aliases in output** — even the alias name can hint at what services your app connects to.

--- a/genesis-living-system-builder/space-apps-guide/custom-domains.md
+++ b/genesis-living-system-builder/space-apps-guide/custom-domains.md
@@ -1,3 +1,7 @@
+---
+description: Connect your own branded domain to a published Genesis app.
+---
+
 # Custom Domains & Branding
 
 **Turn your Genesis apps from "homemade" looking tools into professional business software that looks like you spent a fortune to build it. Your customers will see your brand, not Taskade's.**
@@ -127,6 +131,8 @@ TTL: 3600 (or your registrar's default)
 2. **Click "Verify Domain"** next to your added domain
 3. **Wait for verification** (usually 5-15 minutes)
 4. **SSL certificate generates automatically**
+
+Domain validation and HTTPS now activate faster via Delegated DCV — Cloudflare handles certificate validation automatically on your behalf, so no extra DNS record is required.
 
 #### 5. Assign to Genesis Apps
 

--- a/genesis-living-system-builder/workspaces/knowledge-management.md
+++ b/genesis-living-system-builder/workspaces/knowledge-management.md
@@ -103,16 +103,22 @@ Processing Features:
 }
 ```
 
-#### **Method 3: API-Based Bulk Import**
+#### **Method 3: API — Add Knowledge to an Agent**
+
+The public REST API adds knowledge to an agent by attaching an existing **project** or **media** file. There is no bulk endpoint in v1 — loop over items to add several.
 
 ```bash
-# Bulk upload via API
-curl -X POST "https://api.taskade.com/v1/agents/agent_id/knowledge/bulk" \
-  -H "Authorization: Bearer YOUR_TOKEN" \
-  -F "files[]=@document1.pdf" \
-  -F "files[]=@document2.docx" \
-  -F "files[]=@spreadsheet.xlsx" \
-  -F "metadata={\"category\":\"product_docs\",\"tags\":[\"manual\",\"v2\"]}"
+# Attach a project to an agent's knowledge base
+curl -X POST "https://www.taskade.com/api/v1/agents/{agentId}/knowledge/project" \
+  -H "Authorization: Bearer your_api_token_placeholder" \
+  -H "Content-Type: application/json" \
+  -d '{"projectId": "your_project_id"}'
+
+# Attach an uploaded media file to an agent's knowledge base
+curl -X POST "https://www.taskade.com/api/v1/agents/{agentId}/knowledge/media" \
+  -H "Authorization: Bearer your_api_token_placeholder" \
+  -H "Content-Type: application/json" \
+  -d '{"mediaId": "your_media_id"}'
 ```
 
 ### **Smart Organization Systems**
@@ -434,48 +440,29 @@ AI-Powered Suggestions:
 
 ### **Knowledge API Management**
 
-#### **Bulk Operations API**
+#### **Agent Knowledge API**
+
+The public REST API manages agent knowledge by attaching or removing **projects** and **media** per agent. v1 has no bulk-upload, bulk-update, or knowledge-search endpoint — iterate to add items, and query knowledge by prompting the agent.
 
 ```bash
-# Bulk upload with metadata
-curl -X POST "https://api.taskade.com/v1/knowledge/bulk-upload" \
-  -H "Authorization: Bearer TOKEN" \
-  -H "Content-Type: multipart/form-data" \
-  -F "files[]=@file1.pdf" \
-  -F "files[]=@file2.docx" \
-  -F "config={
-    \"auto_categorize\": true,
-    \"extract_entities\": true,
-    \"generate_summaries\": true,
-    \"create_embeddings\": true
-  }"
+# Add a project to an agent's knowledge base
+curl -X POST "https://www.taskade.com/api/v1/agents/{agentId}/knowledge/project" \
+  -H "Authorization: Bearer your_api_token_placeholder" \
+  -H "Content-Type: application/json" \
+  -d '{"projectId": "your_project_id"}'
 
-# Bulk update knowledge metadata
-curl -X PUT "https://api.taskade.com/v1/knowledge/bulk-update" \
-  -H "Authorization: Bearer TOKEN" \
-  -d '{
-    "updates": [
-      {
-        "id": "doc_123",
-        "tags": ["updated", "v2"],
-        "category": "product_docs"
-      }
-    ]
-  }'
+# Add a media file (upload it via the Media API first)
+curl -X POST "https://www.taskade.com/api/v1/agents/{agentId}/knowledge/media" \
+  -H "Authorization: Bearer your_api_token_placeholder" \
+  -H "Content-Type: application/json" \
+  -d '{"mediaId": "your_media_id"}'
+
+# Remove a project from an agent's knowledge base
+curl -X DELETE "https://www.taskade.com/api/v1/agents/{agentId}/knowledge/project/{projectId}" \
+  -H "Authorization: Bearer your_api_token_placeholder"
 ```
 
-#### **Knowledge Search & Retrieval**
-
-```bash
-# Advanced knowledge search
-curl -X GET "https://api.taskade.com/v1/knowledge/search" \
-  -H "Authorization: Bearer TOKEN" \
-  -G \
-  -d "query=API authentication methods" \
-  -d "categories=technical,security" \
-  -d "limit=10" \
-  -d "include_context=true"
-```
+See the full [Agents API reference](../../apis-living-system-development/comprehensive-api-guide/agents/README.md).
 
 ### **Integration Patterns**
 
@@ -483,17 +470,18 @@ curl -X GET "https://api.taskade.com/v1/knowledge/search" \
 
 ```javascript
 // Sync with content management systems
-const syncCMS = async () => {
+const syncCMS = async (agentId, token) => {
   const cmsContent = await fetchFromCMS();
   
-  const processedContent = await taskadeAPI.knowledge.bulkProcess({
-    sources: cmsContent,
-    processing: {
-      extractEntities: true,
-      generateSummaries: true,
-      categorizeContent: true
-    }
-  });
+  // No bulk endpoint exists in v1 — attach each imported project to the agent:
+  for (const projectId of cmsContent.projectIds) {
+    await fetch(`https://www.taskade.com/api/v1/agents/${agentId}/knowledge/project`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ projectId }),
+    });
+  }
+  const processedContent = cmsContent.projectIds;
   
   return processedContent;
 };
@@ -501,15 +489,7 @@ const syncCMS = async () => {
 
 #### **Real-Time Updates**
 
-```javascript
-// WebSocket connection for live knowledge updates
-const knowledgeSocket = new WebSocket('wss://api.taskade.com/knowledge/live');
-
-knowledgeSocket.on('knowledge_updated', (event) => {
-  console.log(`Knowledge updated: ${event.document_id}`);
-  refreshAgentKnowledge(event.agent_id);
-});
-```
+Taskade does not expose a public WebSocket API. Knowledge changes take effect immediately when you add or remove items via the REST endpoints above. To react to changes programmatically, use an automation trigger (for example, **File Added to Media**) rather than a live socket.
 
 ***
 

--- a/genesis-living-system-builder/workspaces/project-views.md
+++ b/genesis-living-system-builder/workspaces/project-views.md
@@ -10,12 +10,13 @@ Taskade stores information in a flexible tree-structured database. The **same da
 |------|----------|------------------|-----------|
 | **List** | Linear task lists, meeting agendas | Drag-to-indent / reorder, checkboxes | To-do lists, meeting notes, SOPs |
 | **Board** | Kanban workflows, pipelines | Drag cards between columns | Sales pipelines, project stages, sprint boards |
-| **Table** | Spreadsheet-style databases | Inline edit custom fields, sort & filter | CRM, inventory, contact lists |
+| **Table** | Spreadsheet-style databases | Inline edit custom fields, sort & filter, multi-select rows (Shift/Cmd-click) + bulk delete with undo | CRM, inventory, contact lists |
 | **Calendar** | Scheduling & deadlines | Drag tasks on calendar, date pickers | Content calendars, event planning, deadlines |
 | **Mind Map** | Brain-storming & hierarchical planning | Radial drag to create branches | Strategy planning, idea mapping, research |
 | **Org Chart** | Organizational hierarchies | Expand / collapse levels | Team structures, reporting lines, decision trees |
 | **Action** | Mobile-friendly task capture | Quick-add, swipe to complete | Daily tasks, quick capture, on-the-go |
 | **Gantt** | Timeline & dependency tracking | Resize bars to adjust durations | Project timelines, resource planning, dependencies |
+| **Docs (Beta)** | Long-form documents & wikis | Continuous rich-text editing, headings, embeds | Specs, knowledge bases, proposals, SOPs |
 
 All views are backed by the **same underlying data**—update a task in one view and it instantly updates everywhere, thanks to Taskade's real-time engine.
 

--- a/genesis-living-system-builder/workspaces/projects-databases.md
+++ b/genesis-living-system-builder/workspaces/projects-databases.md
@@ -101,6 +101,7 @@ You can also create databases manually:
 |---|---|---|---|
 | **Text (String)** | Names, descriptions, notes | Customer name, product description | Plain text |
 | **Number** | Quantities, prices, scores | Stock level, deal value, rating | Decimal, currency ($, EUR), percent (%) |
+| **Currency** | Pricing, invoices, budgets | Product price, invoice total, budget cap | Pre-formatted as USD; numeric field with currency symbol and decimal precision |
 | **DateTime** | Deadlines, timestamps, schedules | Due date, appointment time | Date only, date + time |
 | **Select** | Single-choice categories | Status, priority, category | Color-coded options |
 | **Multi-select** | Multiple tags/categories | Skills, interests, tags | Color-coded options |


### PR DESCRIPTION
## Genesis & automation accuracy + App Secrets page

Part **1 of 3** of the docs freshness sweep (merge order: **this → API reference → developer changelog**, so every cross-link target exists before the page that references it).

### What's included
- **New page — [App Secrets & External API Calls](genesis-living-system-builder/space-apps-guide/app-secrets.md)**: per-space credential vault (`Settings → Secrets`) + server-side outbound proxy with `{{secret}}` substitution. Conceptual code only (no SDK assumptions); placeholder values throughout.
- **Live-page endpoint fixes** (previously fabricated, now verified against the codebase):
  - `knowledge-management.md` → real routes `POST /agents/{agentId}/knowledge/project|media`, `DELETE …/knowledge/project/{projectId}`, host `www.taskade.com/api/v1`; bulk/search/WebSocket explicitly noted as not in v1.
  - `ai-forms.md` → removed fabricated `/forms/{id}/submissions`; notes no public `/forms` endpoint in v1.
  - `community-and-sharing/README.md` → removed fabricated `api.taskade.com/community/*` fetch.
- **Feature coverage**: automation triggers/actions/integrations (new connectors + sub-hourly schedule), publish-and-clone (Paid Apps/Embed/SEO/White-label/OIDC), custom domains (Delegated DCV), project views, currency preset, Genesis cross-links to App-MCP & App Secrets.
- **`.gitignore`**: scoped negation so the App Secrets *docs page* is tracked without weakening the `*secrets*` credential guard.

### Verification
- Reviewed by a 4-agent adversarial pass; cross-checked against the `taskade/taskcade` `origin/master` tree (fresh through 2026-06-15).
- Secrets scan: clean (only `your_api_token_placeholder`). No `api.taskade.com` hosts on any live page. App Secrets page confirmed placeholder-only.
- GitBook blocks balanced; all relative links + SUMMARY targets resolve (0 missing).

cc @deanzaka @lxcid
