### PR TITLE
docs: Run Your Business on Taskade Genesis — no-code outcome track + dual-audience front door

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 ---
-description: Build apps, deploy AI agents, and automate workflows on Taskade — the AI-native platform with living DNA where projects, agents, and automations connect as one.
+description: Describe your business in plain English and get a real, running app — CRM, client portal, or ops dashboard — with logins and your own domain. No code, plus a full developer API.
 cover: .gitbook/assets/ss-api3.png
 coverY: 0
 ---
 
 # Build on Taskade
 
+<table data-view="cards"><thead><tr><th></th><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td><strong>🛠️ Build a business app — no code</strong></td><td>Describe it in plain English. Get a CRM, client portal, or ops dashboard — with logins and your own domain.</td><td><a href="genesis-living-system-builder/genesis/getting-started.md">Start building →</a></td></tr><tr><td><strong>💻 Build on the API — developers</strong></td><td>REST API v1, Action API v2, MCP, SDK, and webhooks for programmatic access.</td><td><a href="apis-living-system-development/developer-home.md">Developer platform →</a></td></tr></tbody></table>
+
 {% hint style="success" %}
-**New here?** Start with the [Quick Start Guide](getting-started/), learn the platform architecture via [Workspace DNA](genesis-living-system-builder/genesis/workspace-dna.md), or go straight to the [Developer Portal](apis-living-system-development/developer-home.md) to build on the API.
+**Running a real business on a Genesis app?** Follow [Run Your Business on Genesis](genesis-living-system-builder/run-your-business/README.md) — build it, add logins, and put it on your own domain.
 {% endhint %}
 
 ## Welcome to Taskade
 
-**The AI-Native Platform for Building Intelligent Applications**
+**Describe your business in plain English — get a real, running app you can put on your own domain.**
 
 Build complete business applications, websites, and tools using natural language. Taskade combines an **AI app builder** ([Taskade Genesis](https://www.taskade.com/create)), **workflow automation engine**, **AI agents platform**, and **automatic deployment** into a unified workspace.
 
@@ -81,4 +83,4 @@ Use this as the canonical overview: [Workspace DNA](genesis-living-system-builde
 
 ### Explore docs
 
-<table data-view="cards"><thead><tr><th>Topic</th><th data-card-target data-type="content-ref">Link</th></tr></thead><tbody><tr><td>Workspace DNA (canonical)</td><td><a href="genesis-living-system-builder/genesis/workspace-dna.md">workspace-dna.md</a></td></tr><tr><td>Genesis (build apps)</td><td><a href="genesis-living-system-builder/genesis/">genesis</a></td></tr><tr><td>AI Agents</td><td><a href="genesis-living-system-builder/ai-features/ai-agents-getting-started.md">ai-agents-getting-started.md</a></td></tr><tr><td>Automations</td><td><a href="genesis-living-system-builder/automation/">automation</a></td></tr><tr><td>Developers</td><td><a href="apis-living-system-development/developer-home.md">developer-home.md</a></td></tr><tr><td>Help &#x26; Support</td><td><a href="help-center/">help-center</a></td></tr></tbody></table>
+<table data-view="cards"><thead><tr><th>Topic</th><th data-card-target data-type="content-ref">Link</th></tr></thead><tbody><tr><td>Run a business on Genesis</td><td><a href="genesis-living-system-builder/run-your-business/README.md">Run Your Business</a></td></tr><tr><td>Workspace DNA (canonical)</td><td><a href="genesis-living-system-builder/genesis/workspace-dna.md">Workspace DNA</a></td></tr><tr><td>Genesis (build apps)</td><td><a href="genesis-living-system-builder/genesis/">Taskade Genesis</a></td></tr><tr><td>AI Agents</td><td><a href="genesis-living-system-builder/ai-features/ai-agents-getting-started.md">AI Agents: Getting Started</a></td></tr><tr><td>Automations</td><td><a href="genesis-living-system-builder/automation/">Automations</a></td></tr><tr><td>Developers</td><td><a href="apis-living-system-development/developer-home.md">Developer Platform</a></td></tr><tr><td>Help &#x26; Support</td><td><a href="help-center/">Help &#x26; Support</a></td></tr></tbody></table>

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -10,6 +10,81 @@
 
 * [Workspace DNA](genesis-living-system-builder/genesis/workspace-dna.md)
 
+## Taskade Genesis
+
+* [Taskade Genesis Overview](genesis-living-system-builder/genesis/README.md)
+  * [Getting Started](genesis-living-system-builder/genesis/getting-started.md)
+  * [Examples & Templates](genesis-living-system-builder/genesis/examples-and-templates.md)
+  * [How Taskade Genesis Works](genesis-living-system-builder/genesis/how-genesis-works.md)
+  * [Prompt Guide](genesis-living-system-builder/genesis/prompt-guide.md)
+  * [Adding Context](genesis-living-system-builder/genesis/adding-context.md)
+  * [Version History](genesis-living-system-builder/genesis/version-history.md)
+  * [App Analytics](genesis-living-system-builder/genesis/app-analytics.md)
+  * [Debugging Genesis Apps](genesis-living-system-builder/genesis/debugging-genesis-apps.md)
+  * [GitHub Import & Export](genesis-living-system-builder/genesis/github-import-export.md)
+* [Space Apps Guide](genesis-living-system-builder/space-apps-guide/README.md)
+  * [Prompt Library](genesis-living-system-builder/space-apps-guide/genesis-prompt-library.md)
+  * [Advanced Features](genesis-living-system-builder/space-apps-guide/advanced-features.md)
+  * [Put Your App on Your Own Domain](genesis-living-system-builder/space-apps-guide/custom-domains.md)
+  * [App Secrets & External API Calls](genesis-living-system-builder/space-apps-guide/app-secrets.md)
+
+## Run Your Business on Genesis
+
+* [Run Your Business on Genesis](genesis-living-system-builder/run-your-business/README.md)
+  * [From Idea to Live Business](genesis-living-system-builder/run-your-business/from-idea-to-live-business.md)
+  * [Build a Client or Member Portal](genesis-living-system-builder/run-your-business/build-a-client-portal.md)
+  * [Build an Internal Ops Dashboard](genesis-living-system-builder/run-your-business/build-an-ops-dashboard.md)
+  * [Add Login & Roles](genesis-living-system-builder/run-your-business/add-login-and-roles.md)
+  * [Go-Live Checklist](genesis-living-system-builder/run-your-business/go-live-checklist.md)
+
+## AI Features
+
+* [AI Features Overview](genesis-living-system-builder/ai-features/README.md)
+  * [AI Agents Getting Started](genesis-living-system-builder/ai-features/ai-agents-getting-started.md)
+  * [Agent Knowledge & Memory](genesis-living-system-builder/ai-features/agent-knowledge.md)
+  * [Tools for AI Agents](genesis-living-system-builder/ai-features/agent-tools.md)
+  * [AI Agent Teams](genesis-living-system-builder/ai-features/agent-teams.md)
+  * [Multi-Agent Collaboration](genesis-living-system-builder/ai-features/multi-agents.md)
+  * [Image Generation](genesis-living-system-builder/ai-features/image-generation.md)
+  * [Media AI Chat](genesis-living-system-builder/ai-features/media-ai-chat.md)
+  * [Autopilot](genesis-living-system-builder/ai-features/autopilot.md)
+
+## Automations
+
+* [Automations Overview](genesis-living-system-builder/automation/README.md)
+  * [AI Forms](genesis-living-system-builder/automation/ai-forms.md)
+  * [Action & Trigger Reference](genesis-living-system-builder/automation/actions.md)
+  * [Workflow Generator](genesis-living-system-builder/automation/workflow-generator.md)
+  * [Integration Overview](genesis-living-system-builder/automation/comprehensive-integration-guide.md)
+  * [Integration Options](genesis-living-system-builder/automation/integrations.md)
+  * [Automation Recipes](genesis-living-system-builder/automation/recipes.md)
+  * [Advanced Actions](genesis-living-system-builder/automation/advanced-actions.md)
+  * [Comprehensive Integrations](genesis-living-system-builder/automation/comprehensive-integrations.md)
+
+## Workspaces
+
+* [Workspaces Overview](genesis-living-system-builder/workspaces/README.md)
+  * [Projects & Databases](genesis-living-system-builder/workspaces/projects-databases.md)
+  * [Teams](genesis-living-system-builder/workspaces/teams.md)
+  * [Collaboration](genesis-living-system-builder/workspaces/collaboration.md)
+  * [Editing & Formatting](genesis-living-system-builder/workspaces/editing-formatting.md)
+  * [Markdown Support](genesis-living-system-builder/workspaces/markdown.md)
+  * [Import](genesis-living-system-builder/workspaces/import.md)
+  * [Embed](genesis-living-system-builder/workspaces/embed.md)
+  * [Project Views](genesis-living-system-builder/workspaces/project-views.md)
+  * [Advanced Search & Navigation](genesis-living-system-builder/workspaces/advanced-search-navigation.md)
+  * [Knowledge Management](genesis-living-system-builder/workspaces/knowledge-management.md)
+  * [Mobile](genesis-living-system-builder/workspaces/mobile-optimization.md)
+
+## Community & Sharing
+
+* [Community & Sharing](genesis-living-system-builder/community-and-sharing/README.md)
+  * [Publish & Clone](genesis-living-system-builder/community-and-sharing/publish-and-clone.md)
+  * [GenesisAuth](genesis-living-system-builder/community-and-sharing/genesis-auth.md)
+  * [Best Practices](genesis-living-system-builder/community-and-sharing/best-practices.md)
+  * [FAQ](genesis-living-system-builder/community-and-sharing/faq.md)
+  * [Troubleshooting](genesis-living-system-builder/community-and-sharing/troubleshooting.md)
+
 ## APIs & Developer
 
 * [Developer Platform](apis-living-system-development/developer-home.md)
@@ -97,72 +172,6 @@
 * [Bundles & App Kits](apis-living-system-development/bundles.md)
 * [Long-Term Memory](apis-living-system-development/long-term-memory.md)
 * [Autonomous Agents](apis-living-system-development/autonomous-agents.md)
-
-## Taskade Genesis
-
-* [Taskade Genesis Overview](genesis-living-system-builder/genesis/README.md)
-  * [Getting Started](genesis-living-system-builder/genesis/getting-started.md)
-  * [Examples & Templates](genesis-living-system-builder/genesis/examples-and-templates.md)
-  * [How Taskade Genesis Works](genesis-living-system-builder/genesis/how-genesis-works.md)
-  * [Prompt Guide](genesis-living-system-builder/genesis/prompt-guide.md)
-  * [Adding Context](genesis-living-system-builder/genesis/adding-context.md)
-  * [Version History](genesis-living-system-builder/genesis/version-history.md)
-  * [App Analytics](genesis-living-system-builder/genesis/app-analytics.md)
-  * [Debugging Genesis Apps](genesis-living-system-builder/genesis/debugging-genesis-apps.md)
-  * [GitHub Import & Export](genesis-living-system-builder/genesis/github-import-export.md)
-* [Space Apps Guide](genesis-living-system-builder/space-apps-guide/README.md)
-  * [Prompt Library](genesis-living-system-builder/space-apps-guide/genesis-prompt-library.md)
-  * [Advanced Features](genesis-living-system-builder/space-apps-guide/advanced-features.md)
-  * [Custom Domains & Branding](genesis-living-system-builder/space-apps-guide/custom-domains.md)
-  * [App Secrets & External API Calls](genesis-living-system-builder/space-apps-guide/app-secrets.md)
-
-## AI Features
-
-* [AI Features Overview](genesis-living-system-builder/ai-features/README.md)
-  * [AI Agents Getting Started](genesis-living-system-builder/ai-features/ai-agents-getting-started.md)
-  * [Agent Knowledge & Memory](genesis-living-system-builder/ai-features/agent-knowledge.md)
-  * [Tools for AI Agents](genesis-living-system-builder/ai-features/agent-tools.md)
-  * [AI Agent Teams](genesis-living-system-builder/ai-features/agent-teams.md)
-  * [Multi-Agent Collaboration](genesis-living-system-builder/ai-features/multi-agents.md)
-  * [Image Generation](genesis-living-system-builder/ai-features/image-generation.md)
-  * [Media AI Chat](genesis-living-system-builder/ai-features/media-ai-chat.md)
-  * [Autopilot](genesis-living-system-builder/ai-features/autopilot.md)
-
-## Automations
-
-* [Automations Overview](genesis-living-system-builder/automation/README.md)
-  * [AI Forms](genesis-living-system-builder/automation/ai-forms.md)
-  * [Action & Trigger Reference](genesis-living-system-builder/automation/actions.md)
-  * [Workflow Generator](genesis-living-system-builder/automation/workflow-generator.md)
-  * [Integration Overview](genesis-living-system-builder/automation/comprehensive-integration-guide.md)
-  * [Integration Options](genesis-living-system-builder/automation/integrations.md)
-  * [Automation Recipes](genesis-living-system-builder/automation/recipes.md)
-  * [Advanced Actions](genesis-living-system-builder/automation/advanced-actions.md)
-  * [Comprehensive Integrations](genesis-living-system-builder/automation/comprehensive-integrations.md)
-
-## Workspaces
-
-* [Workspaces Overview](genesis-living-system-builder/workspaces/README.md)
-  * [Projects & Databases](genesis-living-system-builder/workspaces/projects-databases.md)
-  * [Teams](genesis-living-system-builder/workspaces/teams.md)
-  * [Collaboration](genesis-living-system-builder/workspaces/collaboration.md)
-  * [Editing & Formatting](genesis-living-system-builder/workspaces/editing-formatting.md)
-  * [Markdown Support](genesis-living-system-builder/workspaces/markdown.md)
-  * [Import](genesis-living-system-builder/workspaces/import.md)
-  * [Embed](genesis-living-system-builder/workspaces/embed.md)
-  * [Project Views](genesis-living-system-builder/workspaces/project-views.md)
-  * [Advanced Search & Navigation](genesis-living-system-builder/workspaces/advanced-search-navigation.md)
-  * [Knowledge Management](genesis-living-system-builder/workspaces/knowledge-management.md)
-  * [Mobile](genesis-living-system-builder/workspaces/mobile-optimization.md)
-
-## Community & Sharing
-
-* [Community & Sharing](genesis-living-system-builder/community-and-sharing/README.md)
-  * [Publish & Clone](genesis-living-system-builder/community-and-sharing/publish-and-clone.md)
-  * [GenesisAuth](genesis-living-system-builder/community-and-sharing/genesis-auth.md)
-  * [Best Practices](genesis-living-system-builder/community-and-sharing/best-practices.md)
-  * [FAQ](genesis-living-system-builder/community-and-sharing/faq.md)
-  * [Troubleshooting](genesis-living-system-builder/community-and-sharing/troubleshooting.md)
 
 ## Updates & Timeline
 

--- a/account-management/credits-and-billing.md
+++ b/account-management/credits-and-billing.md
@@ -9,6 +9,7 @@ Understand how AI credits work in Taskade, how credit packs are priced, and how 
 * [How AI Credits Work](credits-and-billing.md#how-ai-credits-work)
 * [Free Credits](credits-and-billing.md#free-credits)
 * [Paid Plan Credits](credits-and-billing.md#paid-plan-credits)
+* [What Your App Will Cost](credits-and-billing.md#what-your-app-will-cost)
 * [Credit Packs](credits-and-billing.md#credit-packs)
 * [Auto Top-Up](credits-and-billing.md#auto-top-up)
 * [Model-Specific Pricing](credits-and-billing.md#model-specific-pricing)
@@ -60,6 +61,35 @@ Exact credit amounts per tier may change. See the [pricing page](https://www.tas
 {% endhint %}
 
 Max and Enterprise plans get refined credit limits designed for bursty workloads — you won't get throttled mid-task during a heavy generation run.
+
+***
+
+## What Your App Will Cost
+
+If you're building and running a real app on Genesis, the question isn't "how many credits does one request cost" — it's "what in my app burns credits, and how much will it burn as I grow." Use this as a decision guide. For exact, current per-request numbers, always check the in-app model picker; published figures drift as models and pricing change.
+
+### What drives your credit use
+
+| What consumes credits                | What drives the cost (relative)                                                                                       |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| **Genesis app generation & iteration** | Heaviest up front, while you build. Each generate and each "edit with AI" pass costs credits; settles down once the app is stable. |
+| **AI automation steps**              | Scales with how often your automations run and how many AI steps each run includes. A trigger that fires all day costs more than one that fires occasionally. |
+| **An agent answering end-users**     | Scales with the number of people using your published app and how chatty each session is. This is the line item that grows as your app gets traffic. |
+| **Agent / EVE chat**                 | Scales with how much you and your team use AI assistance day to day — drafting, summarizing, asking questions in your workspace. |
+
+Steps that don't call AI — plain forms, stored data, non-AI automation actions — don't draw from your credit balance.
+
+### Right-size it
+
+* **Low usage** — You're building for yourself or a small team, with light traffic and occasional automations. A personal paid tier (Pro direction) is usually enough; top up with a credit pack during a build sprint.
+* **Medium usage** — A team relies on the app, automations run regularly, and a handful of end-users hit your agent daily. Lean toward the Business tier, which also auto-routes to frontier models so you don't manage model choice per task.
+* **High usage** — A public-facing app with steady traffic, an agent answering many end-users, and automations firing throughout the day. Lean toward Max or Enterprise, which are tuned for bursty, high-volume AI workloads without mid-task throttling.
+
+Don't over-buy on day one. Watch your [usage page](credits-and-billing.md#viewing-your-usage) for the first month, then size to what your app actually draws.
+
+### Keep your app from running dry
+
+If real customers use your published app, an agent that runs out of credits mid-session is the worst time to find out. Turn on [**Auto Top-Up**](credits-and-billing.md#auto-top-up) so your balance refills automatically before it hits zero — your customer-facing agent keeps answering instead of stalling on an out-of-credits screen.
 
 ***
 

--- a/genesis-living-system-builder/genesis/README.md
+++ b/genesis-living-system-builder/genesis/README.md
@@ -77,3 +77,5 @@ Start here:
 ### What's next
 
 Edit your app's source from Claude, Cursor, or any IDE via [Genesis App MCP (Beta)](../../apis-living-system-development/genesis-app-mcp.md).
+
+Running a real business on a Genesis app? Follow [Run Your Business on Genesis](../run-your-business/README.md).

--- a/genesis-living-system-builder/genesis/getting-started.md
+++ b/genesis-living-system-builder/genesis/getting-started.md
@@ -338,21 +338,32 @@ Here are what other users built in their first 5 minutes:
 
 ## What's Next?
 
-Congratulations! You've built your first Genesis app. Here's how to take it further:
+Congratulations! You've built your first Genesis app. Here's how to take it further, in two phases.
 
-### **Immediate Next Steps**
+### **Phase 1 — Build**
+
+#### **Immediate Next Steps**
 
 1. **Share your app** with real users and customers
 2. **Monitor the data** coming in and usage patterns
 3. **Collect feedback** on what works well and what could be improved
 4. **Make refinements** based on real-world usage
 
-### **Expanding Your App**
+#### **Expanding Your App**
 
 * **Add more automation** connections to other business tools
 * **Create related apps** for other business processes
 * **Train team members** to build their own solutions
 * **Scale up** with enterprise features as you grow
+
+### **Phase 2 — Run it as a business**
+
+Turn your 5-minute app into a business you run.
+
+* [**Run Your Business on Genesis →**](../run-your-business/README.md) - The full track, from a working app to a live business
+* [**Add login & roles →**](../run-your-business/add-login-and-roles.md) - Gate access and give each user the right view
+* [**Put it on your own domain →**](../space-apps-guide/custom-domains.md) - Publish under your branded domain
+* [**Go-live checklist →**](../run-your-business/go-live-checklist.md) - Final checks before you send real customers in
 
 ### **Learning Resources**
 

--- a/genesis-living-system-builder/run-your-business/README.md
+++ b/genesis-living-system-builder/run-your-business/README.md
@@ -1,0 +1,70 @@
+---
+description: >-
+  Build and run a real business on Taskade Genesis — an ops dashboard, a CRM, or
+  a client portal — with logins and your own domain. No code, no sales call.
+---
+
+# Run Your Business on Genesis
+
+**Describe your business in plain English and get a real, running app — then put it on your own domain with logins and run your operation on it.** No code. No sales call.
+
+Thousands of operators — consultants, clinics, realtors, agencies, construction and logistics teams — already run their day-to-day on a Genesis app. This track stitches the pieces into one path: **build → add your data → add logins → put it on your domain → go live.**
+
+***
+
+## Pick what you're building
+
+{% hint style="info" %}
+New to Genesis? Start with [Your first app in 5 minutes](../genesis/getting-started.md), then come back here to turn it into a business you run.
+{% endhint %}
+
+| You want to… | Start here |
+| --- | --- |
+| See the whole journey end to end | [From idea to live business — the 5 steps](from-idea-to-live-business.md) |
+| Give clients or members a private login | [Build a client or member portal](build-a-client-portal.md) |
+| Run internal operations with your team | [Build an internal ops dashboard](build-an-ops-dashboard.md) |
+| Add sign-in and roles to any app | [Add login and roles](add-login-and-roles.md) |
+| Launch to real users with confidence | [Is your app production-ready?](go-live-checklist.md) |
+
+***
+
+## How the track fits together
+
+{% stepper %}
+{% step %}
+#### Build it
+
+Describe the app you want to Genesis and iterate until it works. → [Getting started](../genesis/getting-started.md)
+{% endstep %}
+
+{% step %}
+#### Make it your system of record
+
+Shape your data and views so the app holds the real records your business runs on. → [Projects & databases](../workspaces/projects-databases.md)
+{% endstep %}
+
+{% step %}
+#### Add logins and roles
+
+Let the right people in — your team internally, or your clients externally — each seeing only what they should. → [Add login and roles](add-login-and-roles.md)
+{% endstep %}
+
+{% step %}
+#### Put it on your domain
+
+Launch the app at your own web address with automatic HTTPS. → [Custom domains](../space-apps-guide/custom-domains.md)
+{% endstep %}
+
+{% step %}
+#### Go live
+
+Run the checklist, right-size your plan and credits, and launch. → [Go-live checklist](go-live-checklist.md)
+{% endstep %}
+{% endstepper %}
+
+## Next steps
+
+* [From idea to live business — the 5 steps](from-idea-to-live-business.md)
+* [Build a client or member portal](build-a-client-portal.md)
+* [Build an internal ops dashboard](build-an-ops-dashboard.md)
+* [What your app will cost](../../account-management/credits-and-billing.md)

--- a/genesis-living-system-builder/run-your-business/add-login-and-roles.md
+++ b/genesis-living-system-builder/run-your-business/add-login-and-roles.md
@@ -1,0 +1,71 @@
+---
+description: >-
+  Add secure sign-in and access control to your Genesis app so the right people
+  see the right things — no code, no third-party auth provider.
+keywords: add login, access control, RBAC, app users, SSO, no-code
+---
+
+# Add login and roles to your app
+
+Genesis apps can ship with real user accounts and secure sign-in built in, powered by [GenesisAuth](../community-and-sharing/genesis-auth.md). To add login, you don't configure anything — you describe the need when you build the app (for example, *"users can sign in to see their own dashboard"*), and Genesis wires up the sign-in component, session handling, and per-user data access automatically.
+
+{% hint style="success" %}
+**The short version:** Describe an app that needs accounts, and your app gets a working login screen. Then manage who gets in from the **App Users** tab in your app's settings.
+{% endhint %}
+
+***
+
+## When to use what
+
+GenesisAuth is part of a broader access-control story. Pick the control that matches who needs to get in and how locked-down it has to be. Every option below is no-code.
+
+| Control | What it does | When to use |
+| --- | --- | --- |
+| **GenesisAuth (App Users)** | Account-based sign-in for your app's end users | Any multi-user app — external clients, members, or customers |
+| **Workspace SSO** | Lets your Taskade workspace members sign in with their existing identity | Internal tools for your own team |
+| **Password-protected public links** | A single shared password on a link | A quick gated preview |
+| **Private / Unlisted visibility** | Controls whether the app can be discovered | Non-indexed, share-by-link only |
+| **Public agent tool opt-out** | Keeps sensitive tools workspace-only | Apps that publish an AI agent |
+
+For external customers and members, reach for **App Users**. For your own staff, **Workspace SSO** means no second account to manage. For a fast, low-stakes gate, a **password-protected link** is enough.
+
+{% hint style="info" %}
+The **App Users** tab is currently in Beta and rolling out across paid plans.
+{% endhint %}
+
+***
+
+## How to turn it on
+
+You won't find a switch to flip — you ask for it in plain language.
+
+1. In Genesis, describe an app that needs accounts. Include phrases like *"a client portal where each client has their own dashboard"* or *"a members-only knowledge base."*
+2. Genesis generates the app **with the sign-in component already in place**.
+3. Open your app's settings and go to the **App Users** tab to invite people, suspend access, or remove accounts.
+
+If your first prompt didn't add login, you can ask Genesis to *"add sign-in for users"* later while editing the app.
+
+For the full walkthrough — the App Users tab, Workspace SSO, custom-domain sign-in, and the security model — see the source page:
+
+{% content-ref url="../community-and-sharing/genesis-auth.md" %}
+[genesis-auth.md](../community-and-sharing/genesis-auth.md)
+{% endcontent-ref %}
+
+***
+
+## Pair it with a custom domain
+
+GenesisAuth works on apps hosted at your own web address with no extra setup. Combining sign-in with a [custom domain](../space-apps-guide/custom-domains.md) gives end users a fully branded, production-ready product.
+
+{% hint style="warning" %}
+**Never put real credentials in your app.** If your app calls an external service that needs an API key or token, store it in [App Secrets](../space-apps-guide/app-secrets.md) — a per-space vault — instead of writing it into your app. Secrets stay on the server and never ship in your exported app bundle.
+{% endhint %}
+
+***
+
+## Next steps
+
+* New to building? Start with [Getting Started](../genesis/getting-started.md).
+* Read the full [GenesisAuth](../community-and-sharing/genesis-auth.md) reference for access control and security best practices.
+* Connect a [custom domain](../space-apps-guide/custom-domains.md) for a branded, production sign-in.
+* See login and roles in action: [Build a client portal](build-a-client-portal.md) and [Build an ops dashboard](build-an-ops-dashboard.md).

--- a/genesis-living-system-builder/run-your-business/build-a-client-portal.md
+++ b/genesis-living-system-builder/run-your-business/build-a-client-portal.md
@@ -1,0 +1,94 @@
+---
+description: >-
+  Build a client portal or member portal where each client logs in and sees only
+  their own info — no code. Keywords: client portal, member portal, login, no-code.
+---
+
+# Build a client or member portal in 10 minutes
+
+**You describe the portal you want. Genesis builds it. Each client logs in and sees only their own record — their projects, their files, their status — and nothing belonging to anyone else.**
+
+No code. No separate login service to wire up. No spreadsheets to share by hand. By the end of this guide you'll have a working, branded portal at your own web address that you can hand to your first client.
+
+***
+
+{% hint style="info" %}
+**This works for any business.** A "client" can be whatever you serve — swap the examples to fit:
+
+* **Consulting** — each client sees their project status, deliverables, and invoices.
+* **Clinic / practice** — each patient sees their appointments, intake forms, and documents.
+* **Course / membership** — each member sees their lessons, progress, and resources.
+* **Agency** — each account sees their campaigns, assets, and reports.
+{% endhint %}
+
+***
+
+{% stepper %}
+{% step %}
+### Describe the portal
+
+Open Genesis and describe what you want in plain English — who logs in, what they see, and what stays private. Genesis turns that description into a working app with a database and screens already wired together.
+
+Start with a prompt like this and edit the bracketed parts for your business:
+
+```
+Build a client portal for my consulting business. Each client signs in with
+their own account and sees only their own dashboard: their active projects,
+the documents I've shared with them, an invoice list, and a status update for
+each project. Clients can never see other clients' information. I sign in as
+the owner and can see and manage every client from one admin view.
+```
+
+The more specific you are about *what each client sees*, the better the first build. New to Genesis? Walk through [Getting Started](../genesis/getting-started.md) first.
+{% endstep %}
+
+{% step %}
+### Give each client their own login
+
+A portal needs real sign-in so the right person sees the right thing. When your prompt mentions per-client accounts, Genesis adds a secure login automatically — no auth provider to set up.
+
+You manage everyone from the **App Users** tab: invite clients by email, suspend access when an engagement ends, and remove accounts you no longer need. See [GenesisAuth — add login & roles](../community-and-sharing/genesis-auth.md) for the full picture.
+
+{% hint style="success" %}
+If your first build didn't add sign-in, just tell Genesis *"add sign-in so each client has their own account"* while editing the app.
+{% endhint %}
+{% endstep %}
+
+{% step %}
+### Show each client only their record
+
+This is what makes it a *portal* instead of a shared page: every client sees only their own data. Conceptually, each record in your portal is tied to the client it belongs to, and the login decides which records that person can open. Client A signs in and sees Client A's projects; Client B never sees them.
+
+You don't configure this by hand — you describe it. Phrases like *"each client sees only their own projects and documents"* tell Genesis to scope the data per user. To shape what's stored and shown, see how [Projects & Databases](../workspaces/projects-databases.md) hold your records, and how [GenesisAuth](../community-and-sharing/genesis-auth.md) ties each record to the signed-in client.
+
+{% hint style="warning" %}
+Always test isolation before going live: sign in as a test client and confirm you can't see anyone else's records.
+{% endhint %}
+{% endstep %}
+
+{% step %}
+### Put it on your domain
+
+A portal at `portal.yourbrand.com` feels like software you built, not a generic link. Once your domain is connected, clients sign in and work entirely under your brand — they never see Taskade in the URL.
+
+Follow [Custom Domains & Branding](../space-apps-guide/custom-domains.md) to connect a subdomain like `portal.yourbrand.com`, add your logo and colors, and turn on automatic HTTPS.
+{% endstep %}
+
+{% step %}
+### Invite your first client
+
+You're ready to go live. Open the **App Users** tab and invite your first client by email — they'll get a link, set a password, and land directly on their own dashboard.
+
+Before you send invites, run the [Go-live checklist](./go-live-checklist.md) so logins, per-client access, and your domain are all confirmed. Then start small: invite one trusted client, watch them use it, and refine the wording or layout by describing the change to Genesis.
+{% endstep %}
+{% endstepper %}
+
+***
+
+## Next steps
+
+* [Add login & roles](./add-login-and-roles.md) — set up sign-in and decide who can see and do what.
+* [Go-live checklist](./go-live-checklist.md) — confirm access, branding, and your domain before inviting clients.
+* [GenesisAuth](../community-and-sharing/genesis-auth.md) — manage clients in the App Users tab.
+* [Custom Domains & Branding](../space-apps-guide/custom-domains.md) — host the portal at `portal.yourbrand.com`.
+* [Getting Started with Genesis](../genesis/getting-started.md) — how describing an app turns into a working one.

--- a/genesis-living-system-builder/run-your-business/build-an-ops-dashboard.md
+++ b/genesis-living-system-builder/run-your-business/build-an-ops-dashboard.md
@@ -1,0 +1,73 @@
+---
+description: >-
+  Build an internal ops dashboard, CRM, or pipeline your whole team logs into —
+  describe it to Genesis, connect live workspace data, and let people in with the
+  Taskade identity they already have.
+keywords: ops dashboard, internal tool, CRM, pipeline, no-code
+---
+
+# Build an internal ops dashboard your team runs on
+
+You don't need a developer to give your team one place to run the day. Describe the board, pipeline, or tracker you wish you had, and Genesis builds it on top of your live workspace data. Your team logs in with the Taskade identity they already use, sees the same up-to-date picture you do, and gets a daily summary in Slack or email — without anyone touching a spreadsheet on the side.
+
+This is the **internal** counterpart to a client portal. Here the people logging in are your own crew, dispatchers, project managers, or coordinators — not your customers.
+
+{% stepper %}
+{% step %}
+### Describe your board or pipeline
+
+Open Genesis and tell it, in plain English, what your team needs to see and do every day. Name the stages, the fields you track, and the views you want. Genesis turns that one description into a working app — the UI, the database behind it, and the structure to keep it organized.
+
+```
+I run field operations for a construction company and need my project
+managers to track every active job from bid to close-out. Show jobs as a
+board with columns for Bid, Scheduled, In Progress, Inspection, and Closed.
+Each job has a site address, client name, assigned crew, start date,
+target completion, and current status. Let managers drag jobs between
+columns and add notes and photos. I want a dashboard view that shows how
+many jobs sit in each stage so I can see where we're stuck at a glance.
+```
+
+Start with one workflow you already run on whiteboards or spreadsheets. You can refine wording, add fields, or change views later just by asking. For the full describe-and-build loop, see [Getting Started with Genesis](../genesis/getting-started.md).
+{% endstep %}
+
+{% step %}
+### Connect live workspace data
+
+The board Genesis builds isn't a static mockup — it's backed by a real project database that acts as your **system of record**. Every job, lead, or shipment is a live record your team reads and updates in real time, and the same data feeds your dashboards, agents, and automations.
+
+That means there's no separate spreadsheet to reconcile. When a manager moves a job to "Inspection," the dashboard counts update instantly for everyone. To understand how projects work as live databases — fields, views, relationships, and permissions — see [Projects & Databases](../workspaces/projects-databases.md).
+{% endstep %}
+
+{% step %}
+### Let your team in with their existing Taskade identity
+
+Because this is an internal tool, your team should sign in with the identity they already have. **Workspace members** use Workspace Single Sign-On — their existing Taskade credentials get them into the app with no second account to manage and no separate user directory to maintain.
+
+This is the key distinction for an internal dashboard: you invite people to the **workspace**, and they reach the app through the identity they already use every day. Set who can view versus edit, and you control access from one place. See [GenesisAuth](../community-and-sharing/genesis-auth.md) for Workspace SSO, the App Users tab, and access control.
+{% endstep %}
+
+{% step %}
+### Wire a daily digest
+
+Give your team a heads-up without anyone having to open the app first thing. Add a scheduled automation that builds a short summary — open jobs, overdue items, what moved yesterday — and sends it to a Slack channel or by email every morning.
+
+Describe it the same way you described the board: tell Genesis what to include and when to send it. The automation reads straight from your live project data, so the digest is always current. See [Automations](../automation/README.md) to build the scheduled summary.
+{% endstep %}
+{% endstepper %}
+
+{% hint style="info" %}
+**Internal vs. external — pick the right access model.**
+
+**Internal (this guide):** your team logs in with their **workspace identity** (Workspace SSO). Use this for ops dashboards, CRMs, and pipelines your own crew runs on.
+
+**External:** clients and customers sign in as **App Users** — separate accounts scoped to the app, not members of your workspace. Use that model when you're building a client-facing portal. See [Build a client portal](./build-a-client-portal.md).
+
+Same Genesis app, two different doors. Choose based on who's logging in.
+{% endhint %}
+
+## Next steps
+
+* [Add login and roles](./add-login-and-roles.md) — control who can view versus edit your dashboard.
+* [Go-live checklist](./go-live-checklist.md) — what to check before your team starts relying on it.
+* [Build a client portal](./build-a-client-portal.md) — the external counterpart, for customers instead of your team.

--- a/genesis-living-system-builder/run-your-business/from-idea-to-live-business.md
+++ b/genesis-living-system-builder/run-your-business/from-idea-to-live-business.md
@@ -1,0 +1,54 @@
+---
+description: >-
+  Build a business app with no code and go live on Taskade Genesis in five
+  steps: describe it, shape your data, add login, brand your domain, then launch.
+---
+
+# From idea to live business — the 5 steps
+
+You have a business problem and an idea for an app that fixes it. This guide is the spine: five steps that take you from a plain-English idea to a real, branded app your customers can sign in to and use. Each step links to a full guide when you want the detail.
+
+***
+
+## Step 1 — Describe your app to Genesis
+
+Start with the problem, not the software. Tell Genesis what you do, who will use the app, and what should happen when they use it. EVE turns that description into a working app — the screens, the data behind them, and the logic that connects them. This is where your idea becomes something you can click. You build by describing changes in plain English, so refining is just another sentence.
+
+→ Full guide: [Getting Started with Genesis](../genesis/getting-started.md)
+
+## Step 2 — Shape your data into a system of record
+
+Every real business app remembers things — customers, bookings, orders, requests. Genesis creates the databases your app needs automatically, and this is where you shape them: name your fields clearly, link related records, and choose the view (table, board, calendar, and more) that matches how you actually work. Get this right and your app stops being a form and becomes a single source of truth your whole business runs on.
+
+→ Full guide: [Projects & Databases](../workspaces/projects-databases.md)
+
+## Step 3 — Add login and roles
+
+The moment real people use your app, you need accounts. GenesisAuth gives every app secure sign-in with no setup — you describe that users should log in, and the sign-in screen is built for you. From the App Users tab you invite people, suspend access, and decide who sees what. This is what turns a shared link into a real multi-user product.
+
+→ Full guide: [GenesisAuth](../community-and-sharing/genesis-auth.md)
+
+## Step 4 — Put it on your own domain
+
+A branded web address makes your app look like software you commissioned, not a tool you borrowed. Connect a domain like `app.yourcompany.com`, point one DNS record at Taskade, and your app goes live with automatic HTTPS — your customers see your brand, never a random link. This is the difference between a prototype and a product people trust with their data.
+
+→ Full guide: [Custom Domains & Branding](../space-apps-guide/custom-domains.md)
+
+## Step 5 — Right-size your plan and go live
+
+Your app runs on AI, and AI runs on credits. Before launch, match your plan and credit balance to how much you expect to use — turn on Auto Top-Up so a busy day never stops your workflows mid-task. Confirm billing is in order, then publish. You are live.
+
+→ Full guide: [Credits & Billing](../../account-management/credits-and-billing.md)
+
+***
+
+{% hint style="success" %}
+**Before you announce it, run the checklist.** Walk the [Go-Live Checklist](./go-live-checklist.md) to confirm sign-in, data, domain, and billing are all ready for real customers.
+{% endhint %}
+
+## Next steps
+
+* [Go-Live Checklist](./go-live-checklist.md) — final pre-launch pass before you share the link
+* [Add Login & Roles](./add-login-and-roles.md) — go deeper on accounts and access control
+* [Getting Started with Genesis](../genesis/getting-started.md) — revisit Step 1 to refine your app
+* [Custom Domains & Branding](../space-apps-guide/custom-domains.md) — polish your branded launch

--- a/genesis-living-system-builder/run-your-business/go-live-checklist.md
+++ b/genesis-living-system-builder/run-your-business/go-live-checklist.md
@@ -1,0 +1,47 @@
+---
+description: >-
+  A go-live checklist for launching your Genesis business app to real users —
+  secrets, logins, your domain, and credits, all in one place.
+---
+
+# Is your app production-ready? A go-live checklist
+
+You described an app, shaped your data, and it works. Before you put it in front of real customers or your team, run this checklist. Each item links to the page that covers it in full — work top to bottom and you'll launch with confidence.
+
+***
+
+### 🔐 Security
+
+* [ ] **Secrets are vaulted, not hardcoded.** Any API key, token, or password your app uses lives in the secret vault — never pasted into a prompt or page. → [App Secrets](../space-apps-guide/app-secrets.md)
+* [ ] **The publish guard passed.** Genesis blocks publishing if it spots a hardcoded credential; resolve any warning before launch. → [App Secrets](../space-apps-guide/app-secrets.md)
+
+### 👤 Access & data
+
+* [ ] **Login and roles are configured.** The right people can sign in, and each role sees only what it should. → [Add login and roles](add-login-and-roles.md)
+* [ ] **Per-user data isolation is verified.** Sign in as a test client and confirm they can see only their own record — never anyone else's. → [Add login and roles](add-login-and-roles.md)
+
+### 🌐 Domain & publishing
+
+* [ ] **Your custom domain is live with HTTPS.** Your app loads at your own address with the padlock showing. → [Put your app on your own domain](../space-apps-guide/custom-domains.md)
+* [ ] **Visibility and publish strategy are set correctly.** Public, unlisted, or private — match it to who should reach the app. → [Publishing & cloning](../community-and-sharing/publish-and-clone.md)
+
+### 💳 Cost & reliability
+
+* [ ] **Auto Top-Up is enabled.** A customer-facing agent should never hit an out-of-credits screen mid-session — set a top-up so credits replenish automatically. → [Credits & billing](../../account-management/credits-and-billing.md)
+
+### ✅ Final checks
+
+* [ ] **Test data is purged.** Remove the dummy records you created while building.
+* [ ] **A version snapshot is taken**, so you can roll back if a later change misbehaves. → [Publishing & cloning](../community-and-sharing/publish-and-clone.md)
+
+***
+
+{% hint style="success" %}
+**You're ready to launch.** Every box checked means your app is secure, access-controlled, on your domain, and won't run out of credits in front of a customer.
+{% endhint %}
+
+## Next steps
+
+* [From idea to live business — the 5 steps](from-idea-to-live-business.md)
+* [Add login and roles to your app](add-login-and-roles.md)
+* [Put your app on your own domain](../space-apps-guide/custom-domains.md)


### PR DESCRIPTION
## Run Your Business on Taskade Genesis — no-code outcome track + dual-audience front door

Part 2 of 3. Reframes the docs so the **non-technical "build & run my business app" audience** is served first-class alongside developers — and gives that audience a complete outcome track. **Zero rendering regression** (0 broken internal links/anchors; GitBook blocks balanced; SUMMARY reorder is zero-target-loss).

### Dual-audience front door
- **README**: outcome-first description + subhead; a **2-card chooser** — *Build a business app (no code)* vs *Build on the API (developers)*; human-readable link labels.
- **SUMMARY**: moved the build sections (Taskade Genesis → **Run Your Business** → AI Features → Automations → Workspaces → Community) **above** the APIs & Developer section (intact, re-sequenced below); relabeled "Custom Domains & Branding" → **"Put Your App on Your Own Domain."** Verified: 250 targets, 0 removed, 0 missing.

### New "Run Your Business on Taskade Genesis" track
Goal-shaped guides that stitch existing pages into one journey (build → data → login → domain → go-live → cost):
- **Hub** + **From idea to live business (5 steps)** + **Build a client/member portal** + **Build an internal ops dashboard** + **Add login & roles** + **Is your app production-ready? (go-live checklist)**.
- Wired into `getting-started`, the Taskade Genesis `README`, and a new qualitative **"What your app will cost"** section in `credits-and-billing`.

### Safety
No internal identifiers, no placeholder metrics or names, GitBook-safe markup throughout.

cc @deanzaka @lxcid
