### PR TITLE
docs: consistent intent tables + heading style across section landings

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Software should be alive. And now, it is.
 
 <figure><img src=".gitbook/assets/genesis-overview.gif" alt="Build a full app from one prompt with Taskade Genesis"><figcaption>One prompt → a working app — agents, integrations, and automations built in.</figcaption></figure>
 
-### 🏗️ Platform Capabilities
+### Platform capabilities
 
 | Capability               | Description                                                    | Learn More                                                                                                  |
 | ------------------------ | -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
@@ -55,25 +55,25 @@ Taskade works best when three parts stay connected. **Memory** stores knowledge.
 
 Use this as the canonical overview: [Workspace DNA](genesis-living-system-builder/genesis/workspace-dna.md).
 
-### 🚀 Quick Start
+### Quick start
 
-#### 🚀 **Build Your First App** (5 minutes)
+#### Build your first app (5 minutes)
 
 1. [**Follow the Tutorial**](genesis-living-system-builder/genesis/getting-started.md) - Step-by-step app building
 2. [**Copy Working Prompts**](genesis-living-system-builder/genesis/examples-and-templates.md) - Proven templates
 3. [**Browse Community Apps**](https://www.taskade.com/community) - Apps, templates, and workflows for every industry
 
-#### 🤖 **Create AI Agents** (10 minutes)
+#### Create AI agents (10 minutes)
 
 1. [**AI Agent Tutorial**](genesis-living-system-builder/ai-features/ai-agents-getting-started.md) - Your first AI assistant
 2. [**Agent Prompt Library**](genesis-living-system-builder/space-apps-guide/genesis-prompt-library.md) - Ready-to-use configurations
 
-#### ⚡ **Set Up Automations** (15 minutes)
+#### Set up automations (15 minutes)
 
 1. [**Automation Getting Started**](genesis-living-system-builder/automation/) - Build your first workflow
 2. [**Integration Guide**](genesis-living-system-builder/automation/integrations.md) - 100+ supported services
 
-#### 💻 **For Developers**
+#### For developers
 
 * [**Developer Platform**](apis-living-system-development/developer-home.md) - The developer portal: APIs, SDK, and MCP
 * [**REST API v1**](apis-living-system-development/comprehensive-api-guide/README.md) - Complete RESTful reference (full task CRUD)

--- a/genesis-living-system-builder/ai-features/README.md
+++ b/genesis-living-system-builder/ai-features/README.md
@@ -5,6 +5,18 @@ description: >-
 
 # AI Features Overview
 
+AI features let you build agents that reason over your workspace, learn from your knowledge, use tools, and work together in teams.
+
+## I want to…
+
+| I want to… | Go to |
+| --- | --- |
+| Create my first agent | [AI Agents Getting Started](ai-agents-getting-started.md) |
+| Give an agent knowledge and memory | [Agent Knowledge & Memory](agent-knowledge.md) |
+| Let an agent use tools and take actions | [Tools for AI Agents](agent-tools.md) |
+| Build a team of agents | [AI Agent Teams](agent-teams.md) |
+| Run multiple agents together | [Multi-Agent Collaboration](multi-agents.md) |
+
 **Think. Learn. Adapt.** Taskade AI features form the living intelligence layer of Workspace DNA, creating systems that understand, evolve, and provide increasingly intelligent value with every interaction.
 
 {% hint style="success" %}
@@ -67,6 +79,13 @@ Next:
 
 * Build apps with agents: [Living Systems That Transform Business](../genesis/)
 * Put actions on autopilot: [Living Motion Overview](../automation/)
+
+## Next steps
+
+* [AI Agents Getting Started](ai-agents-getting-started.md) — create one agent for one job
+* [Tools for AI Agents](agent-tools.md) — let agents take action, not just write text
+* [Multi-Agent Collaboration](multi-agents.md) — coordinate agents on bigger work
+* [taskade.com/community](https://www.taskade.com/community) — browse agent templates and get help
 
 {% hint style="info" %}
 This page stays overview-level. Model comparisons, tool catalogs, and deep agent training patterns live in the linked guides.

--- a/genesis-living-system-builder/automation/README.md
+++ b/genesis-living-system-builder/automation/README.md
@@ -5,6 +5,19 @@ description: >-
 
 # Automations Overview
 
+Automations let you build trigger-and-action workflows that run on their own — connecting Taskade to your tools and letting agents act 24/7.
+
+## I want to…
+
+| I want to… | Go to |
+| --- | --- |
+| Build my first workflow | [Action & Trigger Reference](actions.md) |
+| Find available triggers and actions | [Action & Trigger Reference](actions.md) |
+| Generate a workflow from a prompt | [Workflow Generator](workflow-generator.md) |
+| Connect an integration | [Integration Overview](comprehensive-integration-guide.md) |
+| See every available connector | [Integration Options](integrations.md) |
+| Start from a ready-made recipe | [Automation Recipes](recipes.md) |
+
 **Act. Execute. Evolve.** Taskade Automations are the living motion layer of Workspace DNA, transforming static workflows into intelligent, adaptive systems that act with precision and learn from every execution.
 
 {% hint style="success" %}
@@ -111,6 +124,13 @@ Connect your workflows to popular tools across the [Taskade integrations](https:
 * Pick tools to connect: [Integration Overview](comprehensive-integration-guide.md)
 * Full list of connectors: [Integration Options](integrations.md)
 * Troubleshoot: [Living System Troubleshooting](../community-and-sharing/troubleshooting.md)
+
+## Next steps
+
+* [Action & Trigger Reference](actions.md) — pick a trigger and add your first actions
+* [Automation Recipes](recipes.md) — start from a proven workflow
+* [Integration Overview](comprehensive-integration-guide.md) — connect the tools you already use
+* [Living System Troubleshooting](../community-and-sharing/troubleshooting.md) — fix issues and get help
 
 {% hint style="info" %}
 This page stays overview-level. Deep trigger/action lists, templates, and advanced patterns live in the reference pages above.

--- a/genesis-living-system-builder/genesis/README.md
+++ b/genesis-living-system-builder/genesis/README.md
@@ -5,6 +5,19 @@ description: >-
 
 # Taskade Genesis Overview
 
+Genesis lets you turn a plain-English prompt into a live application — UI, data, agents, and automations — running on your own workspace.
+
+## I want to…
+
+| I want to… | Go to |
+| --- | --- |
+| Build my first app fast | [Getting Started](getting-started.md) |
+| Understand how Genesis works | [How Taskade Genesis Works](how-genesis-works.md) |
+| Write better prompts | [Prompt Guide](prompt-guide.md) |
+| Give my app the right context | [Adding Context](adding-context.md) |
+| See real apps and starting points | [Examples & Templates](examples-and-templates.md) |
+| Run a real business on a Genesis app | [Run Your Business on Genesis](../run-your-business/README.md) |
+
 **Living Software. Living DNA. Living Intelligence.**
 
 **Build Without Permission.**\
@@ -79,3 +92,10 @@ Start here:
 Edit your app's source from Claude, Cursor, or any IDE via [Genesis App MCP (Beta)](../../apis-living-system-development/genesis-app-mcp.md).
 
 Running a real business on a Genesis app? Follow [Run Your Business on Genesis](../run-your-business/README.md).
+
+## Next steps
+
+* [Getting Started](getting-started.md) — build your first living system in 5 minutes
+* [Prompt Guide](prompt-guide.md) — get sharper results from your prompts
+* [Run Your Business on Genesis](../run-your-business/README.md) — take an app to production
+* [taskade.com/community](https://www.taskade.com/community) — browse community apps and get help


### PR DESCRIPTION
## Consistent content patterns — intent tables + heading style

Part 3 of 3. Standardizes the cross-page content vocabulary so the docs read as one product, and makes section landings answer-first for both people and answer engines. **Zero regression** (0 broken links/anchors; blocks balanced).

- **"I want to…" intent tables**: an outcome-first one-liner + an `## I want to…` table (intent → the page that delivers it) as the first content block on the **Taskade Genesis**, **AI Features**, and **Automations** section READMEs — plus a consistent **"Next steps"** footer on each (17/17 links resolve).
- **Heading discipline**: README section headings are sentence-case and emoji-free for a cleaner, consistent type scale (slug-neutral — anchor integrity re-verified, 0 broken).

cc @deanzaka @lxcid
