### PR TITLE
docs: consistent product naming (Taskade Genesis / Taskade EVE) + qualitative examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ coverY: 0
 <table data-view="cards"><thead><tr><th></th><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td><strong>🛠️ Build a business app — no code</strong></td><td>Describe it in plain English. Get a CRM, client portal, or ops dashboard — with logins and your own domain.</td><td><a href="genesis-living-system-builder/genesis/getting-started.md">Start building →</a></td></tr><tr><td><strong>💻 Build on the API — developers</strong></td><td>REST API v1, Action API v2, MCP, SDK, and webhooks for programmatic access.</td><td><a href="apis-living-system-development/developer-home.md">Developer platform →</a></td></tr></tbody></table>
 
 {% hint style="success" %}
-**Running a real business on a Genesis app?** Follow [Run Your Business on Genesis](genesis-living-system-builder/run-your-business/README.md) — build it, add logins, and put it on your own domain.
+**Running a real business on a Taskade Genesis app?** Follow [Run Your Business on Genesis](genesis-living-system-builder/run-your-business/README.md) — build it, add logins, and put it on your own domain.
 {% endhint %}
 
 ## Welcome to Taskade
@@ -18,7 +18,7 @@ coverY: 0
 
 Build complete business applications, websites, and tools using natural language. Taskade combines an **AI app builder** ([Taskade Genesis](https://www.taskade.com/create)), **workflow automation engine**, **AI agents platform**, and **automatic deployment** into a unified workspace.
 
-**Build Without Permission. Start with Genesis. Your workspace is the foundation.**
+**Build Without Permission. Start with Taskade Genesis. Your workspace is the foundation.**
 
 We believe the future of work isn't just humans using AI. It's humans and AI working as one.
 
@@ -83,4 +83,4 @@ Use this as the canonical overview: [Workspace DNA](genesis-living-system-builde
 
 ### Explore docs
 
-<table data-view="cards"><thead><tr><th>Topic</th><th data-card-target data-type="content-ref">Link</th></tr></thead><tbody><tr><td>Run a business on Genesis</td><td><a href="genesis-living-system-builder/run-your-business/README.md">Run Your Business</a></td></tr><tr><td>Workspace DNA (canonical)</td><td><a href="genesis-living-system-builder/genesis/workspace-dna.md">Workspace DNA</a></td></tr><tr><td>Genesis (build apps)</td><td><a href="genesis-living-system-builder/genesis/">Taskade Genesis</a></td></tr><tr><td>AI Agents</td><td><a href="genesis-living-system-builder/ai-features/ai-agents-getting-started.md">AI Agents: Getting Started</a></td></tr><tr><td>Automations</td><td><a href="genesis-living-system-builder/automation/">Automations</a></td></tr><tr><td>Developers</td><td><a href="apis-living-system-development/developer-home.md">Developer Platform</a></td></tr><tr><td>Help &#x26; Support</td><td><a href="help-center/">Help &#x26; Support</a></td></tr></tbody></table>
+<table data-view="cards"><thead><tr><th>Topic</th><th data-card-target data-type="content-ref">Link</th></tr></thead><tbody><tr><td>Run a business on Taskade Genesis</td><td><a href="genesis-living-system-builder/run-your-business/README.md">Run Your Business</a></td></tr><tr><td>Workspace DNA (canonical)</td><td><a href="genesis-living-system-builder/genesis/workspace-dna.md">Workspace DNA</a></td></tr><tr><td>Taskade Genesis (build apps)</td><td><a href="genesis-living-system-builder/genesis/">Taskade Genesis</a></td></tr><tr><td>AI Agents</td><td><a href="genesis-living-system-builder/ai-features/ai-agents-getting-started.md">AI Agents: Getting Started</a></td></tr><tr><td>Automations</td><td><a href="genesis-living-system-builder/automation/">Automations</a></td></tr><tr><td>Developers</td><td><a href="apis-living-system-development/developer-home.md">Developer Platform</a></td></tr><tr><td>Help &#x26; Support</td><td><a href="help-center/">Help &#x26; Support</a></td></tr></tbody></table>

--- a/account-management/README.md
+++ b/account-management/README.md
@@ -64,7 +64,7 @@ Full details: [taskade.com/pricing](https://www.taskade.com/pricing)
 
 ### AI Credits
 
-AI credits are consumed when you use AI features (agents, chat, automations with AI steps, Genesis app generation). Credits reset monthly. Check your usage at Settings > Billing > Usage.
+AI credits are consumed when you use AI features (agents, chat, automations with AI steps, Taskade Genesis app generation). Credits reset monthly. Check your usage at Settings > Billing > Usage.
 
 ## Security
 

--- a/account-management/credits-and-billing.md
+++ b/account-management/credits-and-billing.md
@@ -22,7 +22,7 @@ Understand how AI credits work in Taskade, how credit packs are priced, and how 
 
 ## How AI Credits Work
 
-Every AI request in Taskade — prompting an agent, running an automation with AI, generating a Genesis app — consumes credits. The credit cost depends on the model:
+Every AI request in Taskade — prompting an agent, running an automation with AI, generating a Taskade Genesis app — consumes credits. The credit cost depends on the model:
 
 * **Lightweight models** cost fewer credits per request.
 * **Frontier models** (top-tier reasoning models) cost more.
@@ -75,7 +75,7 @@ If you're building and running a real app on Genesis, the question isn't "how ma
 | **Genesis app generation & iteration** | Heaviest up front, while you build. Each generate and each "edit with AI" pass costs credits; settles down once the app is stable. |
 | **AI automation steps**              | Scales with how often your automations run and how many AI steps each run includes. A trigger that fires all day costs more than one that fires occasionally. |
 | **An agent answering end-users**     | Scales with the number of people using your published app and how chatty each session is. This is the line item that grows as your app gets traffic. |
-| **Agent / EVE chat**                 | Scales with how much you and your team use AI assistance day to day — drafting, summarizing, asking questions in your workspace. |
+| **Agent / Taskade EVE chat**         | Scales with how much you and your team use AI assistance day to day — drafting, summarizing, asking questions in your workspace. |
 
 Steps that don't call AI — plain forms, stored data, non-AI automation actions — don't draw from your credit balance.
 

--- a/apis-living-system-development/api-v2-reference.md
+++ b/apis-living-system-development/api-v2-reference.md
@@ -42,7 +42,7 @@ Taskade ships **two** public HTTP APIs. They share the same authentication.
 | Project update | ✅ | ❌ (create / complete / restore / copy only) |
 | Prompt an agent | ❌ | ✅ `promptAgent` |
 | Agent lifecycle (create/update/delete) | Partial | ✅ |
-| Bundles (export/import Genesis apps) | ❌ | ✅ |
+| Bundles (export/import Taskade Genesis apps) | ❌ | ✅ |
 | Reference | [Comprehensive API Guide](comprehensive-api-guide/) | This page |
 
 **Rule of thumb:** reach for **v1** when you need to write tasks or manage task metadata; reach for **v2** for agent prompting, agent lifecycle, bundles, and simpler list/read flows.

--- a/apis-living-system-development/bundles.md
+++ b/apis-living-system-development/bundles.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Export and import complete Genesis apps and workspaces as portable bundles
+  Export and import complete Taskade Genesis apps and workspaces as portable bundles
   using the Action API v2.
 ---
 

--- a/apis-living-system-development/developer-home.md
+++ b/apis-living-system-development/developer-home.md
@@ -59,7 +59,7 @@ graph TB
 | Hit endpoints from any language | [REST API v1](comprehensive-api-guide/README.md) + [Action API v2](api-v2-reference.md) |
 | Expose Taskade data to Claude Desktop, Cursor, or other MCP clients | [Workspace MCP](workspace-mcp.md) + [Advanced](workspace-mcp-advanced.md) |
 | Give a Taskade agent third-party capabilities | [MCP Connectors](workspace-mcp-advanced.md#mcp-connectors) |
-| Edit Genesis app source code from your IDE | [Hosted MCP (Genesis App)](genesis-app-mcp.md) |
+| Edit Taskade Genesis app source code from your IDE | [Hosted MCP (Genesis App)](genesis-app-mcp.md) |
 | Receive real-time events in your app | [Webhooks](webhooks.md) |
 | Understand long-term memory | [Long-Term Memory](long-term-memory.md) |
 | Build agents that run without prompting | [Autonomous Agents](autonomous-agents.md) |

--- a/apis-living-system-development/developers/README.md
+++ b/apis-living-system-development/developers/README.md
@@ -55,7 +55,7 @@ Official libraries and tools:
 
 * `@taskade/sdk` -- TypeScript SDK (Preview — not yet on public npm) ([Quickstart](../sdk-quickstart.md))
 * [@taskade/mcp-server](https://github.com/taskade/mcp) -- Workspace MCP Server for Claude, Cursor, Claude Code ([Setup Guide](../workspace-mcp.md))
-* Genesis App MCP (Beta) -- edit Genesis app source from your IDE ([Setup Guide](../genesis-app-mcp.md))
+* Taskade Genesis App MCP (Beta) -- edit Genesis app source from your IDE ([Setup Guide](../genesis-app-mcp.md))
 * REST API with OpenAPI spec
 * Webhook integrations
 

--- a/apis-living-system-development/genesis-app-mcp.md
+++ b/apis-living-system-development/genesis-app-mcp.md
@@ -10,7 +10,7 @@ description: >-
 
 ## Which MCP do I want?
 
-Taskade has three MCP surfaces. This page covers the **hosted Genesis App MCP**.
+Taskade has three MCP surfaces. This page covers the **hosted Taskade Genesis App MCP**.
 
 | Surface | Transport | Auth | Touches | Plan |
 | --- | --- | --- | --- | --- |
@@ -40,7 +40,7 @@ MCP currently **cannot** create, modify, or delete:
 - Automations or flows
 - Uploaded media
 
-Those resources appear in the MCP filesystem but are **read-only**. To modify them, keep using Taskade directly or EVE (Taskade's built-in AI assistant). We're actively working on expanding MCP's write scope — stay tuned.
+Those resources appear in the MCP filesystem but are **read-only**. To modify them, keep using Taskade directly or Taskade EVE (the built-in AI assistant). We're actively working on expanding MCP's write scope — stay tuned.
 
 ## Requirements
 

--- a/apis-living-system-development/long-term-memory.md
+++ b/apis-living-system-development/long-term-memory.md
@@ -53,7 +53,7 @@ graph TB
 
 **Why this matters:**
 
-- **Transparency** — you see exactly what EVE remembers.
+- **Transparency** — you see exactly what Taskade EVE remembers.
 - **Controllability** — edit or delete memory blocks like any project content.
 - **Composability** — use memory as an input to automations, agents, or other apps.
 - **Portability** — memory is part of your workspace, not locked in a separate system.

--- a/apis-living-system-development/sdk-cookbook.md
+++ b/apis-living-system-development/sdk-cookbook.md
@@ -277,7 +277,7 @@ To send data **into** Taskade instead, use an inbound webhook trigger — see [I
 
 ## Bundles (Import/Export)
 
-Export a Genesis app as a portable bundle, then import elsewhere. See [Bundles & App Kits](bundles.md) for the full schema.
+Export a Taskade Genesis app as a portable bundle, then import elsewhere. See [Bundles & App Kits](bundles.md) for the full schema.
 
 ```typescript
 // Export a space's bundle (exportBundle returns the bundle under `item`)

--- a/apis-living-system-development/workspace-mcp-advanced.md
+++ b/apis-living-system-development/workspace-mcp-advanced.md
@@ -56,7 +56,7 @@ graph LR
 | --- | --- | --- | --- |
 | **Inbound** | AI tools like Claude Desktop | "Claude, list my Taskade projects" | [Workspace MCP](workspace-mcp.md) (this page adds advanced config) |
 | **Outbound** | Taskade agents | Agent calls a third-party service via MCP | [MCP Connectors](#mcp-connectors) section below |
-| **Genesis App MCP** | Genesis app builders | Edit app source from an IDE | [Genesis App MCP (Beta)](genesis-app-mcp.md) |
+| **Taskade Genesis App MCP** | Genesis app builders | Edit app source from an IDE | [Genesis App MCP (Beta)](genesis-app-mcp.md) |
 
 ---
 

--- a/apis-living-system-development/workspace-mcp.md
+++ b/apis-living-system-development/workspace-mcp.md
@@ -6,7 +6,7 @@ description: >-
 
 # Workspace MCP
 
-> **Editing Genesis app source code instead?** See [Hosted MCP — Genesis App (Beta)](genesis-app-mcp.md) for the remote server that writes to your app's source files.
+> **Editing Taskade Genesis app source code instead?** See [Hosted MCP — Genesis App (Beta)](genesis-app-mcp.md) for the remote server that writes to your app's source files.
 
 Workspace MCP connects [Claude Desktop](https://claude.ai), [Cursor](https://cursor.sh), [Claude Code](https://claude.com/claude-code), [Windsurf](https://codeium.com/windsurf), [VS Code](https://code.visualstudio.com/), or any MCP-compatible AI tool to your Taskade **workspace content** — workspaces, projects, tasks, agents, and media. It's a small server you run locally that wraps the [REST API v1](comprehensive-api-guide/README.md), so it has full task read/write access.
 

--- a/automation/triggers.md
+++ b/automation/triggers.md
@@ -190,8 +190,8 @@ The Task Assigned trigger automatically runs workflows whenever a task is assign
 
 | Use Case | Automation Flow | Business Impact |
 |----------|-----------------|-----------------|
-| **Task Onboarding** | Task Assigned → Generate Checklist → Send Welcome Email | 40% faster task preparation |
-| **Content Creation** | Task Assigned → Create Draft → Set Up Review Process | 60% reduction in content creation time |
+| **Task Onboarding** | Task Assigned → Generate Checklist → Send Welcome Email | Faster, consistent task preparation |
+| **Content Creation** | Task Assigned → Create Draft → Set Up Review Process | Drafts and review steps created automatically |
 | **Project Communication** | Task Assigned → Notify Stakeholders → Set Up Status Updates | Improved team coordination |
 | **Resource Allocation** | Task Assigned → Update Capacity → Balance Workload | Optimized resource utilization |
 | **Quality Control** | Task Assigned → Validate Requirements → Flag Missing Info | Consistent task quality |
@@ -283,7 +283,7 @@ The Task Due trigger automatically runs workflows when a task's due date is reac
 
 | Use Case | Automation Flow | Business Impact |
 |----------|-----------------|-----------------|
-| **Content Publishing** | Task Due → Generate Content → Publish | 100% on-time content delivery |
+| **Content Publishing** | Task Due → Generate Content → Publish | On-time, scheduled content delivery |
 | **Email Automation** | Task Due → Send Reminder → Follow-up Sequence | Improved response rates |
 | **Project Milestones** | Task Due → Review Process → Next Phase | Accelerated project completion |
 | **Quality Control** | Task Due → Automated Review → Approval Gate | Consistent quality standards |
@@ -378,7 +378,7 @@ The New Comment trigger automatically runs workflows whenever a comment is added
 
 | Use Case | Automation Flow | Business Impact |
 |----------|-----------------|-----------------|
-| **Team Feedback Alerts** | New Comment → Slack Message → Add Follow-up Task | 50% faster feedback response |
+| **Team Feedback Alerts** | New Comment → Slack Message → Add Follow-up Task | Faster feedback response |
 | **Documentation Updates** | New Comment → Append to Google Doc | Real-time knowledge base updates |
 | **Bug Tracking** | New Comment → Create GitHub Issue → Assign Developer | Streamlined issue management |
 | **Meeting Scheduling** | New Comment → Create Calendar Event → Send Confirmation | Improved client communication |
@@ -505,9 +505,9 @@ The Task Added trigger automatically runs workflows whenever a new task is creat
 
 | Use Case | Automation Flow | Business Impact |
 |----------|-----------------|-----------------|
-| **Team Notifications** | Task Added → Slack Message | 50% faster response to new work |
+| **Team Notifications** | Task Added → Slack Message | Faster response to new work |
 | **Task Tracking** | Task Added → Google Sheets Row | Complete project visibility |
-| **Content Generation** | Task Added → AI Generation | 60% faster content creation |
+| **Content Generation** | Task Added → AI Generation | Drafts generated automatically |
 | **Lead Processing** | Task Added → CRM Update | Streamlined sales workflow |
 | **Quality Control** | Task Added → Validation Check | Consistent task standards |
 

--- a/changelog/2017-2019/README.md
+++ b/changelog/2017-2019/README.md
@@ -1,6 +1,6 @@
 # 2017-2019 Foundation Years: Platform Genesis
 
-**From Humble Beginnings to Growth** - The collaborative productivity platform takes shape, establishing the foundational DNA that would eventually evolve into Genesis.
+**From Humble Beginnings to Growth** - The collaborative productivity platform takes shape, establishing the foundational DNA that would eventually evolve into Taskade Genesis.
 
 > *"Every great journey begins with a single step. On December 5, 2017, we announced 'Taskade is coming!' We had no idea we were starting the path to Genesis - to a future where one prompt would become one app. But every great platform begins with great collaboration."*
 
@@ -29,7 +29,7 @@ The foundational years that established collaborative productivity as the bedroc
 **🚀 Highlights:**
 - **💰 Funding Round** - Series Seed investment secured
 - **🎯 Accelerator Program** - Completed prestigious accelerator program
-- **👥 2,000+ Active Teams** - Growing user base across industries
+- **👥 Growing Team Base** - Expanding user base across industries
 - **🚀 Future Vision** - Accelerated product development for remote collaboration
 
 **✨ Other Improvements:** Expanded team, enhanced product roadmap, better customer support, enterprise features development.
@@ -134,8 +134,8 @@ The foundational years that established collaborative productivity as the bedroc
 - 2019: Multiple project views, advanced features, major funding round
 
 **📈 Growth Metrics:**
-- From beta to 2,000+ active teams
-- $5M Series Seed funding from top-tier investors
+- From beta to a growing base of active teams
+- Series Seed funding from institutional investors
 - International expansion with 12 language support
 - Cross-platform apps (Web, iOS, Android, Mac, Windows, Linux)
 

--- a/changelog/2020/README.md
+++ b/changelog/2020/README.md
@@ -1,6 +1,6 @@
 # 2020 Remote Collaboration: Essential Infrastructure for Distributed Teams
 
-**The Remote Work Revolution** - 20+ major releases make Taskade essential infrastructure for distributed teams worldwide, preparing the collaborative foundation for Genesis.
+**The Remote Work Revolution** - 20+ major releases make Taskade essential infrastructure for distributed teams worldwide, preparing the collaborative foundation for Taskade Genesis.
 
 > *"2020 was our trial by fire. As the world went remote, we became the nervous system of distributed teams everywhere. Every feature we built, every problem we solved, was shaping us into something bigger - the foundation for intelligent collaboration that would one day become Genesis."*
 

--- a/changelog/2021/README.md
+++ b/changelog/2021/README.md
@@ -1,6 +1,6 @@
 # 2021 Major Redesigns: The Modern Foundation
 
-**Complete Platform Transformation** - Taskade V4 launches with modern interface and powerful features, preparing the foundation for AI integration and eventual Genesis.
+**Complete Platform Transformation** - Taskade V4 launches with modern interface and powerful features, preparing the foundation for AI integration and eventual Taskade Genesis.
 
 > *"2021 was the year we rebuilt everything from the ground up. Taskade V4 wasn't just a redesign - it was preparation for what we knew was coming: the age of AI. Every pixel, every interaction, every feature was designed to be a foundation for intelligence to flourish."*
 

--- a/changelog/2022/README.md
+++ b/changelog/2022/README.md
@@ -1,6 +1,6 @@
 # 2022 AI & Automation: Think in Tasks, Not Prompts
 
-**The Arrival of Intelligence** - December 12th changes everything. AI becomes contextually aware of projects and tasks, laying the groundwork for Genesis.
+**The Arrival of Intelligence** - December 12th changes everything. AI becomes contextually aware of projects and tasks, laying the groundwork for Taskade Genesis.
 
 > *"December 12, 2022 was our moment of breakthrough. AI stopped being a separate tool and became part of the workspace itself. It understood context, anticipated needs, and began the journey toward true collaboration. This was the day we learned to think in tasks, not prompts."*
 

--- a/changelog/2023/README.md
+++ b/changelog/2023/README.md
@@ -2,7 +2,7 @@
 
 **The AI Transformation Year** - 18+ major AI releases. The evolution from AI assistant to intelligent teammates who think, learn, and collaborate.
 
-> *"2023 was the year we taught AI to be more than a tool. Our agents became teammates, collaborators, and specialized experts. They didn't just respond to commands - they anticipated needs, worked together, and laid the foundation for what would become Genesis."*
+> *"2023 was the year we taught AI to be more than a tool. Our agents became teammates, collaborators, and specialized experts. They didn't just respond to commands - they anticipated needs, worked together, and laid the foundation for what would become Taskade Genesis."*
 
 ---
 

--- a/changelog/2024/README.md
+++ b/changelog/2024/README.md
@@ -1,6 +1,6 @@
 # 2024 Living DNA: Intelligence + Action + Knowledge + Evolution
 
-**The Breakthrough Year** - AI agents become autonomous teams. The four pillars of intelligent systems emerge to lay the foundation for Genesis.
+**The Breakthrough Year** - AI agents become autonomous teams. The four pillars of intelligent systems emerge to lay the foundation for Taskade Genesis.
 
 > *"This was the year everything came together. Intelligence inherited from projects, actions coordinated through agents, knowledge shared across systems, and evolution became continuous. The Living DNA framework wasn't just built - it came alive."*
 

--- a/changelog/2025/README.md
+++ b/changelog/2025/README.md
@@ -2,13 +2,13 @@
 
 **From Static Apps to Living Systems** - The paradigm shift that transforms software from tools into intelligent companions powered by Workspace DNA.
 
-> _"August 9, 2025 marked the birth of living software. Genesis proved that applications could be alive - learning from users, adapting to needs, and evolving with business growth. Your workspace became a living brain, your projects living memory, your agents living intelligence, your automations living motion."_
+> _"August 9, 2025 marked the birth of living software. Taskade Genesis proved that applications could be alive - learning from users, adapting to needs, and evolving with business growth. Your workspace became a living brain, your projects living memory, your agents living intelligence, your automations living motion."_
 
 ***
 
 ## 🧬 The Living Software Revolution
 
-Eight years of evolution culminate in the Workspace DNA trinity: **Memory** (Projects & Knowledge), **Intelligence** (AI Agents & EVE), and **Motion** (Automations & Actions) working in harmony to create systems that think, learn, and act.
+Eight years of evolution culminate in the Workspace DNA trinity: **Memory** (Projects & Knowledge), **Intelligence** (AI Agents & Taskade EVE), and **Motion** (Automations & Actions) working in harmony to create systems that think, learn, and act.
 
 Each release advances the living software vision, strengthening the DNA strands and their integration into complete, intelligent business solutions.
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -5,7 +5,7 @@ description: >-
 
 # Changelog (2017 - 2025)
 
-Welcome to Taskade's changelog! This chronicles our extraordinary journey from a simple task management tool to **Genesis** - the world's first AI-powered platform that turns a single prompt into a living, intelligent application.
+Welcome to Taskade's changelog! This chronicles our extraordinary journey from a simple task management tool to **Taskade Genesis** - the world's first AI-powered platform that turns a single prompt into a living, intelligent application.
 
 > _"From humble beginnings to the HyperCard moment for the AI era. This is the story of how teams learned to think in tasks, not prompts, and how one prompt became one app."_
 

--- a/contributing/vision/README.md
+++ b/contributing/vision/README.md
@@ -45,4 +45,4 @@ Just as HyperCard unleashed a wave of creativity by making software development 
 
 * Start building: [Quick Start Guide](../../getting-started/)
 * Understand the foundation: [Workspace DNA](../../genesis-living-system-builder/genesis/workspace-dna.md)
-* Go deeper: [Genesis Overview](../../genesis-living-system-builder/genesis/)
+* Go deeper: [Taskade Genesis Overview](../../genesis-living-system-builder/genesis/)

--- a/features/README.md
+++ b/features/README.md
@@ -309,37 +309,37 @@ Result: 80% reduction in compliance violations, 50% faster audit preparation
 
 ### **Measuring Enterprise ROI**
 
-#### **Financial Metrics**
-- **Cost Reduction**: 40-70% decrease in operational expenses through automation
-- **Productivity Gains**: 60-85% improvement in team productivity and efficiency
-- **Revenue Impact**: 25-50% increase in sales and customer satisfaction metrics
-- **Time-to-Market**: 75% faster delivery of new products and services
+#### **Financial Outcomes**
+- **Cost Reduction**: Lower operational expenses by automating manual work
+- **Productivity Gains**: Free teams from repetitive tasks to focus on higher-value work
+- **Revenue Impact**: Respond to customers faster and follow up more consistently
+- **Time-to-Market**: Ship new products and services sooner
 
-#### **Operational Metrics**
-- **Error Reduction**: 80-95% decrease in operational errors and exceptions
-- **Process Efficiency**: 50-75% reduction in manual process steps and handoffs
-- **Decision Speed**: 3-5x faster strategic and operational decision-making
-- **Scalability Gains**: Ability to handle 10x growth without proportional headcount increases
+#### **Operational Outcomes**
+- **Error Reduction**: Fewer manual errors through automated, repeatable workflows
+- **Process Efficiency**: Remove manual steps and handoffs between systems
+- **Decision Speed**: Make decisions on real-time data instead of stale reports
+- **Scalability**: Handle growth without proportional headcount increases
 
-#### **Strategic Metrics**
-- **Innovation Velocity**: 4x faster development and deployment of new capabilities
-- **Market Responsiveness**: Real-time adaptation to market changes and customer needs
+#### **Strategic Outcomes**
+- **Innovation Velocity**: Build and deploy new capabilities faster
+- **Market Responsiveness**: Adapt to market changes and customer needs in real time
 - **Competitive Advantage**: Sustained differentiation through intelligent operations
 - **Future-Proofing**: Systems that evolve with changing business requirements
 
-### **Enterprise Success Stories**
+### **Example Scenarios**
 
-#### **Global Manufacturing Company**
-*"Living systems transformed our quality control from reactive to predictive. We now prevent 85% of defects before they reach customers, saving $2.3M annually."*
+#### **Manufacturing**
+Move quality control from reactive to predictive — surface likely defects earlier in the line so teams can act before products ship.
 
-#### **Healthcare Network**
-*"Our patient care coordination system learns from every interaction. Wait times dropped 60%, patient satisfaction increased 40%, and we reduced administrative overhead by 50%."*
+#### **Healthcare**
+Coordinate patient care across teams, with a shared system of record that reduces administrative back-and-forth.
 
-#### **Financial Services Firm**
-*"Living compliance systems maintain 99.9% accuracy while reducing audit preparation time from 3 months to 2 weeks. Risk detection improved by 300%."*
+#### **Financial Services**
+Keep compliance steps consistent and auditable, so audit preparation is continuous rather than a last-minute scramble.
 
-#### **Retail Corporation**
-*"Our inventory intelligence system maintains perfect stock levels across 500 stores. Out-of-stock incidents dropped 90%, while overstock costs decreased 65%."*
+#### **Retail**
+Track inventory across locations with automated reorder alerts to reduce both stockouts and overstock.
 
 ### **Getting Started with Enterprise Living Systems**
 

--- a/genesis-living-system-builder/ai-features/README.md
+++ b/genesis-living-system-builder/ai-features/README.md
@@ -72,7 +72,7 @@ Start here:
 ### Where it shows up
 
 * In your workspace as an assistant.
-* Inside Genesis apps as an AI layer.
+* Inside Taskade Genesis apps as an AI layer.
 * In automations as a decision-maker.
 
 Next:

--- a/genesis-living-system-builder/ai-features/agent-knowledge.md
+++ b/genesis-living-system-builder/ai-features/agent-knowledge.md
@@ -26,7 +26,7 @@
 
 Agent knowledge is the information your custom AI agents use to provide **contextual, accurate responses**. It combines pre-trained AI capabilities with **your own data** — documents, URLs, projects, and media — to create agents that truly understand your business.
 
-> **Workspace DNA connection:** Knowledge is what transforms a generic AI into a specialist. The more knowledge you add, the richer your [Workspace DNA](../genesis/how-genesis-works.md) becomes, and the smarter all your Genesis apps get.
+> **Workspace DNA connection:** Knowledge is what transforms a generic AI into a specialist. The more knowledge you add, the richer your [Workspace DNA](../genesis/how-genesis-works.md) becomes, and the smarter all your Taskade Genesis apps get.
 
 ---
 

--- a/genesis-living-system-builder/ai-features/ai-agents-getting-started.md
+++ b/genesis-living-system-builder/ai-features/ai-agents-getting-started.md
@@ -205,7 +205,7 @@ Select the right AI model based on your needs:
 
 ## 🧠 Understanding Agent Knowledge & Memory
 
-Your agent's knowledge is what makes it truly powerful for your business. This is the foundation that powers Genesis apps - your workspace's living DNA.
+Your agent's knowledge is what makes it truly powerful for your business. This is the foundation that powers Taskade Genesis apps - your workspace's living DNA.
 
 ### Types of Agent Memory
 

--- a/genesis-living-system-builder/ai-features/autopilot.md
+++ b/genesis-living-system-builder/ai-features/autopilot.md
@@ -7,7 +7,7 @@
 - [Overview](#overview)
 - [What Autopilot Creates](#what-autopilot-creates)
 - [When to Use Autopilot](#when-to-use-autopilot)
-- [Autopilot vs. Genesis](#autopilot-vs-genesis)
+- [Autopilot vs. Taskade Genesis](#autopilot-vs-genesis)
 - [Tutorial: Use Autopilot](#tutorial-use-autopilot)
 - [Expand Your Workspace](#expand-your-workspace)
   - [Generate New Automations](#generate-new-automations)

--- a/genesis-living-system-builder/ai-features/image-generation.md
+++ b/genesis-living-system-builder/ai-features/image-generation.md
@@ -26,7 +26,7 @@ You can generate images for your Taskade Genesis apps **natively** — no extra 
 |---|---|
 | **Chat-native creation** | Describe what you need, generate instantly in EVE chat |
 | **Auto-save to Media** | Every generated image is stored in your workspace Media tab |
-| **Built for Genesis apps** | Use images in websites, tools, dashboards, and more |
+| **Built for Taskade Genesis apps** | Use images in websites, tools, dashboards, and more |
 | **Multiple aspect ratios** | 1:1 (square), 16:9 (landscape), 9:16 (portrait) |
 | **Batch generation** | Generate sets of consistent images in a single prompt |
 | **Reusable everywhere** | Use in any Genesis app, project, or agent knowledge base |

--- a/genesis-living-system-builder/ai-features/media-ai-chat.md
+++ b/genesis-living-system-builder/ai-features/media-ai-chat.md
@@ -21,7 +21,7 @@
 
 Media AI Chat lets you **have conversations with your files, projects, and media** using Taskade's AI. Upload documents, images, videos, or connect projects — then ask questions, extract insights, and generate content directly from your media.
 
-> **Genesis connection:** Every file you upload to a Genesis app or discuss in Media AI Chat is stored in your workspace's Media library, enriching your [Workspace DNA](../genesis/how-genesis-works.md) and making all future apps and agents smarter.
+> **Taskade Genesis connection:** Every file you upload to a Genesis app or discuss in Media AI Chat is stored in your workspace's Media library, enriching your [Workspace DNA](../genesis/how-genesis-works.md) and making all future apps and agents smarter.
 
 ---
 

--- a/genesis-living-system-builder/ai-features/multi-agents.md
+++ b/genesis-living-system-builder/ai-features/multi-agents.md
@@ -159,7 +159,7 @@ Multi-agent chats support both AI agents and human team members in the same conv
 | **Within workspace** | Team members | Agents are available to all workspace members by default |
 | **Cross-workspace** | Other workspaces | Publish publicly → Clone |
 | **Public** | Anyone | Publish with public toggle |
-| **Embedded in Genesis app** | App users | Add agent chat widget to your Genesis app |
+| **Embedded in Taskade Genesis app** | App users | Add agent chat widget to your Genesis app |
 
 ---
 

--- a/genesis-living-system-builder/automation/actions.md
+++ b/genesis-living-system-builder/automation/actions.md
@@ -133,7 +133,7 @@ The Find Task(s) action enables dynamic task retrieval within automation workflo
 
 | Use Case                    | Automation Flow                                               | Business Impact                   |
 | --------------------------- | ------------------------------------------------------------- | --------------------------------- |
-| **Overdue Task Alerts**     | Schedule → Find Tasks (overdue) → Send Email                  | 40% reduction in missed deadlines |
+| **Overdue Task Alerts**     | Schedule → Find Tasks (overdue) → Send Email                  | Fewer missed deadlines            |
 | **Weekly Progress Reports** | Schedule → Find Tasks (completed this week) → Generate Report | Better project visibility         |
 | **Workload Balancing**      | Schedule → Find Tasks (by assignee) → Reassign Tasks          | Optimized team productivity       |
 | **Quality Assurance**       | Schedule → Find Tasks (missing details) → Flag for Review     | Improved task quality             |
@@ -247,7 +247,7 @@ The Update Custom Fields action allows you to automatically update custom fields
 | **Add Project to Agent Knowledge**   | Automatically trains AI agents with project content | `agentId`, `projectId`             | Keep agents updated with latest project information |
 
 {% hint style="info" %}
-**Genesis self-assembly capability:** Flows can programmatically assemble and configure agents at runtime — this is the mechanism that powers Genesis self-assembly features. If you are building advanced Genesis flows, check the in-app action picker for current availability of agent-assembly steps; the exact surface exposed to automation builders may vary by plan.
+**Taskade Genesis self-assembly capability:** Flows can programmatically assemble and configure agents at runtime — this is the mechanism that powers Genesis self-assembly features. If you are building advanced Genesis flows, check the in-app action picker for current availability of agent-assembly steps; the exact surface exposed to automation builders may vary by plan.
 {% endhint %}
 
 ### Ask Agent With Structured Output Settings
@@ -837,9 +837,9 @@ The Categorize with AI action automatically analyzes, classifies, and organizes 
 
 | Use Case               | Automation Flow                                 | Business Impact                         |
 | ---------------------- | ----------------------------------------------- | --------------------------------------- |
-| **Sentiment Analysis** | Form Submission → Categorize → Route Response   | 60% faster customer response time       |
-| **Lead Qualification** | New Contact → Categorize → Assign Sales Rep     | 40% improvement in conversion rates     |
-| **Support Routing**    | Ticket Created → Categorize → Assign Agent      | 50% reduction in ticket resolution time |
+| **Sentiment Analysis** | Form Submission → Categorize → Route Response   | Faster, routed customer responses       |
+| **Lead Qualification** | New Contact → Categorize → Assign Sales Rep     | Leads routed to the right rep           |
+| **Support Routing**    | Ticket Created → Categorize → Assign Agent      | Tickets categorized and assigned        |
 | **Content Moderation** | User Post → Categorize → Approve/Reject         | Maintains community standards           |
 | **Feedback Analysis**  | Survey Response → Categorize → Update Dashboard | Data-driven product improvements        |
 

--- a/genesis-living-system-builder/automation/integrations.md
+++ b/genesis-living-system-builder/automation/integrations.md
@@ -5,7 +5,7 @@ Taskade connects to **100+ tools and services** across communication, productivi
 ## Enhanced Integration Features
 
 ### **Enterprise-Grade Reliability**
-- **99.99% uptime** across all integrations
+- **High availability** across all integrations
 - **Advanced error handling** with automatic retries and recovery
 - **Real-time monitoring** and alerting for integration health
 - **Enhanced security** with additional data protection layers

--- a/genesis-living-system-builder/automation/workflow-generator.md
+++ b/genesis-living-system-builder/automation/workflow-generator.md
@@ -20,7 +20,7 @@
 
 The Workflow Generator builds complex automation flows from **natural language**. Describe what you want in plain English, and the AI creates complete workflows with triggers, conditions, branches, loops, and integrations across 100+ services — no drag-and-drop, no manual configuration.
 
-> **Genesis connection:** Genesis apps automatically generate workflow automations as part of the Execution pillar. The Workflow Generator lets you create additional automations or modify existing ones. Each automation adds **+5 points** to your [Intelligence Score](https://www.taskade.com/learn/genesis).
+> **Taskade Genesis connection:** Genesis apps automatically generate workflow automations as part of the Execution pillar. The Workflow Generator lets you create additional automations or modify existing ones. Each automation adds **+5 points** to your [Intelligence Score](https://www.taskade.com/learn/genesis).
 
 ---
 

--- a/genesis-living-system-builder/community-and-sharing/README.md
+++ b/genesis-living-system-builder/community-and-sharing/README.md
@@ -5,7 +5,7 @@ description: >-
 
 # Sharing: Living Systems
 
-**Turn your brilliant Genesis app into something that helps business owners everywhere. Share what you've built, discover amazing solutions from others, and copy complete apps with just one click.**
+**Turn your brilliant Taskade Genesis app into something that helps business owners everywhere. Share what you've built, discover amazing solutions from others, and copy complete apps with just one click.**
 
 {% hint style="success" %}
 **Latest Features!** Revolutionary app forking, embeddable public agents, and professional publishing with paywalls are now live! Share your Genesis apps globally, monetize premium solutions, and fork complete applications with one click.

--- a/genesis-living-system-builder/community-and-sharing/best-practices.md
+++ b/genesis-living-system-builder/community-and-sharing/best-practices.md
@@ -1,6 +1,6 @@
 # Best Practices for Genesis Success
 
-Learn from successful Genesis users to build better apps faster and avoid common pitfalls.
+Learn from successful Taskade Genesis users to build better apps faster and avoid common pitfalls.
 
 ## Writing Effective Prompts
 

--- a/genesis-living-system-builder/community-and-sharing/faq.md
+++ b/genesis-living-system-builder/community-and-sharing/faq.md
@@ -4,7 +4,7 @@
 
 ### What is Taskade Genesis?
 
-Genesis is like having a personal app developer who works instantly. You describe a business problem in plain English (like "I need customers to book appointments online"), and Genesis builds a complete working app for you - no coding, no setup, no technical knowledge required.
+Taskade Genesis is like having a personal app developer who works instantly. You describe a business problem in plain English (like "I need customers to book appointments online"), and Genesis builds a complete working app for you - no coding, no setup, no technical knowledge required.
 
 ### How is this different from other app builders?
 
@@ -188,8 +188,7 @@ Yes! Genesis can integrate with:
 
 **Reliability measures:**
 
-* **99.9% uptime SLA** for paid plans
-* **Multiple data centers** for redundancy
+* **High-availability infrastructure** with redundancy
 * **Automatic failover** systems
 * **Real-time status monitoring** at taskade.statuspage.io
 * **Data backups** stored in multiple locations

--- a/genesis-living-system-builder/community-and-sharing/genesis-auth.md
+++ b/genesis-living-system-builder/community-and-sharing/genesis-auth.md
@@ -1,6 +1,6 @@
 # GenesisAuth
 
-A dedicated security layer for Taskade Genesis apps. Every Genesis app can ship with real user accounts and secure sign-in — no code, no third-party provider setup, no DevOps.
+A dedicated security layer for Taskade Genesis apps. Every Taskade Genesis app can ship with real user accounts and secure sign-in — no code, no third-party provider setup, no DevOps.
 
 ---
 

--- a/genesis-living-system-builder/community-and-sharing/publish-and-clone.md
+++ b/genesis-living-system-builder/community-and-sharing/publish-and-clone.md
@@ -26,7 +26,7 @@
 
 ## Overview
 
-Once you've built an app with Genesis, you can share it with the world in multiple ways — from private team tools to public community templates. This guide covers every publishing, sharing, and distribution option available.
+Once you've built an app with Taskade Genesis, you can share it with the world in multiple ways — from private team tools to public community templates. This guide covers every publishing, sharing, and distribution option available.
 
 > **Haven't built an app yet?** Start with [Create Your First App](../genesis/getting-started.md).
 

--- a/genesis-living-system-builder/community-and-sharing/troubleshooting.md
+++ b/genesis-living-system-builder/community-and-sharing/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting Your Genesis App
 
-Building with AI is like explaining your business to a really smart assistant who wants to help but sometimes needs more details. Don't worry if your first app isn't perfect - that's completely normal! Think of it as refining your idea until Genesis understands exactly what you need.
+Building with AI is like explaining your business to a really smart assistant who wants to help but sometimes needs more details. Don't worry if your first app isn't perfect - that's completely normal! Think of it as refining your idea until Taskade Genesis understands exactly what you need.
 
 ## Why Things Go Sideways
 

--- a/genesis-living-system-builder/genesis/README.md
+++ b/genesis-living-system-builder/genesis/README.md
@@ -5,18 +5,18 @@ description: >-
 
 # Taskade Genesis Overview
 
-Genesis lets you turn a plain-English prompt into a live application — UI, data, agents, and automations — running on your own workspace.
+Taskade Genesis lets you turn a plain-English prompt into a live application — UI, data, agents, and automations — running on your own workspace.
 
 ## I want to…
 
 | I want to… | Go to |
 | --- | --- |
 | Build my first app fast | [Getting Started](getting-started.md) |
-| Understand how Genesis works | [How Taskade Genesis Works](how-genesis-works.md) |
+| Understand how Taskade Genesis works | [How Taskade Genesis Works](how-genesis-works.md) |
 | Write better prompts | [Prompt Guide](prompt-guide.md) |
 | Give my app the right context | [Adding Context](adding-context.md) |
 | See real apps and starting points | [Examples & Templates](examples-and-templates.md) |
-| Run a real business on a Genesis app | [Run Your Business on Genesis](../run-your-business/README.md) |
+| Run a real business on a Taskade Genesis app | [Run Your Business on Genesis](../run-your-business/README.md) |
 
 **Living Software. Living DNA. Living Intelligence.**
 
@@ -29,7 +29,7 @@ Genesis lets you turn a plain-English prompt into a live application — UI, dat
 It builds on the same data, agents, and automations you already use.
 
 {% hint style="success" %}
-**New to Genesis?** Follow [Your First Living System in 5 Minutes](getting-started.md).
+**New to Taskade Genesis?** Follow [Your First Living System in 5 Minutes](getting-started.md).
 {% endhint %}
 
 ### What Genesis can build
@@ -45,7 +45,7 @@ See templates: [Living System Examples & Templates](examples-and-templates.md).
 ### How Genesis works (short version)
 
 1. You describe an app and its workflow.
-2. Genesis generates a UI and data model.
+2. Taskade Genesis generates a UI and data model.
 3. The app runs on your workspace, not a separate backend.
 
 The key idea is reuse.\
@@ -89,9 +89,9 @@ Start here:
 
 ### What's next
 
-Edit your app's source from Claude, Cursor, or any IDE via [Genesis App MCP (Beta)](../../apis-living-system-development/genesis-app-mcp.md).
+Edit your app's source from Claude, Cursor, or any IDE via [Taskade Genesis App MCP (Beta)](../../apis-living-system-development/genesis-app-mcp.md).
 
-Running a real business on a Genesis app? Follow [Run Your Business on Genesis](../run-your-business/README.md).
+Running a real business on a Taskade Genesis app? Follow [Run Your Business on Genesis](../run-your-business/README.md).
 
 ## Next steps
 

--- a/genesis-living-system-builder/genesis/adding-context.md
+++ b/genesis-living-system-builder/genesis/adding-context.md
@@ -25,7 +25,7 @@ When you build apps with Taskade Genesis, you can **upload reference files** to 
 
 ## What You Can Use as Context
 
-Genesis works with a wide range of file types to understand your requirements:
+Taskade Genesis works with a wide range of file types to understand your requirements:
 
 ### Brand & Design Files
 

--- a/genesis-living-system-builder/genesis/app-analytics.md
+++ b/genesis-living-system-builder/genesis/app-analytics.md
@@ -23,7 +23,7 @@ Every published Taskade Genesis app includes a **built-in analytics dashboard** 
 
 ## Analytics Dashboard
 
-Access analytics from your Genesis app's dashboard view. Data updates in real-time.
+Access analytics from your Taskade Genesis app's dashboard view. Data updates in real-time.
 
 <!-- Screenshot: Full analytics dashboard overview -->
 

--- a/genesis-living-system-builder/genesis/debugging-genesis-apps.md
+++ b/genesis-living-system-builder/genesis/debugging-genesis-apps.md
@@ -5,7 +5,7 @@
 ## Table of Contents
 
 - [Overview](#overview)
-- [Genesis Debugging Framework (GDF)](#genesis-debugging-framework-gdf)
+- [Taskade Genesis Debugging Framework (GDF)](#genesis-debugging-framework-gdf)
   - [Layer 1: Failure Classification](#layer-1-failure-classification)
   - [Layer 2: Diagnostic Checklist](#layer-2-diagnostic-checklist)
   - [Layer 3: Root Cause Documentation](#layer-3-root-cause-documentation)

--- a/genesis-living-system-builder/genesis/examples-and-templates.md
+++ b/genesis-living-system-builder/genesis/examples-and-templates.md
@@ -2,7 +2,7 @@
 
 **Copy these proven prompts and build working business apps in minutes.**
 
-Each example includes the exact prompt, expected results, and real success metrics from businesses using Genesis.
+Each example includes the exact prompt, expected results, and real success metrics from businesses using Taskade Genesis.
 
 {% hint style="success" %}
 **Looking for more examples?** Browse 1000+ community-built apps, dashboards, and tools at [**taskade.com/community**](https://www.taskade.com/community)
@@ -85,7 +85,7 @@ Try these live apps — all built with Taskade Genesis, all verified and working
 | **AI Prompt Evaluator** | Score and optimize AI prompts with suggestions       | [Try It →](https://www.taskade.com/share/apps/svnocpc6jk90oa6g) |
 | **RSS-Feed Inbox**      | Aggregate and filter content from multiple RSS feeds | [Try It →](https://www.taskade.com/share/apps/9wtiiu6m11617l8l) |
 
-**Fun & Games** (yes, Genesis can build games too)
+**Fun & Games** (yes, Taskade Genesis can build games too)
 
 | App                       | What It Does                                           | Live Demo                                                       |
 | ------------------------- | ------------------------------------------------------ | --------------------------------------------------------------- |
@@ -94,12 +94,12 @@ Try these live apps — all built with Taskade Genesis, all verified and working
 | **Etch-a-Sketch**         | Digital drawing canvas inspired by the classic toy     | [Try It →](https://www.taskade.com/share/apps/qi09802b4qqvd31e) |
 
 {% hint style="success" %}
-**That's 70+ app templates across 11 categories** — from CRM dashboards to playable games. Every one of these was built by typing a prompt into Genesis. [**Browse all 1000+ community apps →**](https://www.taskade.com/community)
+**That's 70+ app templates across 11 categories** — from CRM dashboards to playable games. Every one of these was built by typing a prompt into Taskade Genesis. [**Browse all 1000+ community apps →**](https://www.taskade.com/community)
 {% endhint %}
 
 ### **📚 Template Gallery**
 
-Taskade features hundreds of project frameworks you can use to kickstart all kinds of projects. All templates in the [**Template Gallery**](https://www.taskade.com/templates) are fully customizable and Genesis-ready.
+Taskade features hundreds of project frameworks you can use to kickstart all kinds of projects. All templates in the [**Template Gallery**](https://www.taskade.com/templates) are fully customizable and Taskade Genesis-ready.
 
 **Available Template Categories:**
 
@@ -145,7 +145,7 @@ Start with [Workspace DNA](../../genesis-living-system-builder/genesis/workspace
 
 ### **Landing Pages**
 
-| Genesis App             | Prompt Used                                                                                                                                                                   | Preview Link                                                  |
+| Taskade Genesis App             | Prompt Used                                                                                                                                                                   | Preview Link                                                  |
 | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
 | **SaaS Product Page**   | `"Create a modern project management SaaS landing page with a dark theme, dashboard mockup showing tasks and team collaboration features, animated elements, and clear CTAs"` | [Try it →](https://landing-page-mirage-jdglsxqn.taskade.app/) |
 | **Designer Portfolio**  | `"Build a clean portfolio landing page for a UX designer showcasing projects, testimonials, and contact information with modern design"`                                      | [Try it →](https://portfolio-palette-2fl0un79.taskade.app/)   |
@@ -153,13 +153,13 @@ Start with [Workspace DNA](../../genesis-living-system-builder/genesis/workspace
 
 ### **Forms & Data Collection**
 
-| Genesis App            | Prompt Used                                                                                                                     | Preview Link                                                 |
+| Taskade Genesis App            | Prompt Used                                                                                                                     | Preview Link                                                 |
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
 | **Lead Capture Form**  | `"Build a lead generation form for my digital marketing agency with fields for name, email, company, and budget range"`         | [Try it →](https://lead-capture-form-pmtoelno.taskade.app/)  |
 | **Event Registration** | `"Create an event registration form with attendee details, meal preferences, and payment integration via Stripe"`               | [Try it →](https://event-registration-68n46o73.taskade.app/) |
 | **Product Order Form** | `"Build a custom product order form for my handmade jewelry business with image gallery, size options, and quantity selection"` | [Try it →](https://product-order-form-xpi6oe6j.taskade.app/) |
 
-💡 **Pro Tip:** These are real, working apps. Click the preview links to see exactly what Genesis can build for your business!
+💡 **Pro Tip:** These are real, working apps. Click the preview links to see exactly what Taskade Genesis can build for your business!
 
 ***
 
@@ -169,13 +169,13 @@ Start with [Workspace DNA](../../genesis-living-system-builder/genesis/workspace
 
 **Business Challenge:** _"Customers leave reviews on third-party sites, but we don't see them quickly enough to address problems or thank happy customers."_
 
-**Genesis Prompt:**
+**Taskade Genesis Prompt:**
 
 ```
 I run a restaurant and need customers to submit feedback about their dining experience. They should rate food quality (1-5), service speed (1-5), and overall satisfaction (1-5), plus leave optional comments and upload photos of their food if they want to. When someone gives us 3 stars or lower on any category, immediately send a Slack alert to our manager with the customer's feedback so we can follow up personally within 30 minutes. Also send a thank you email to every customer who submits feedback, and create a weekly summary report of all ratings and comments for our team meetings.
 ```
 
-**What Genesis Built:**
+**What Taskade Genesis Built:**
 
 * **Smart Feedback Form** - Easy rating system with photo uploads
 * **Instant Manager Alerts** - Slack notifications for low ratings (≤3 stars)
@@ -191,7 +191,7 @@ I run a restaurant and need customers to submit feedback about their dining expe
 
 ### Online Reservation System
 
-**Genesis Prompt:**
+**Taskade Genesis Prompt:**
 
 ```
 I own a fine dining restaurant and need customers to make reservations online for dinner service. They should select their preferred date, time (6:00-10:00 PM in 30-minute slots), party size (2-8 people), and any special dietary requirements or occasion notes. When someone makes a reservation, automatically send them a confirmation email with our address and parking information, add the reservation to our Google Calendar, and notify our host staff via Slack. If someone tries to book a time that's already full, suggest the next available slot within 1 hour of their requested time.
@@ -209,7 +209,7 @@ I own a fine dining restaurant and need customers to make reservations online fo
 
 ### Yoga Studio Class Booking
 
-**Genesis Prompt:**
+**Taskade Genesis Prompt:**
 
 ```
 I run a yoga studio with 4 instructors and need clients to book classes online and pay deposits in advance. Clients should see available classes with instructor names, class types (Beginner Hatha, Vinyasa Flow, Power Yoga), and remaining spots (max 15 per class). When they book, charge a $10 deposit via Stripe, send them a confirmation email with class details and what to bring, and add the class to their Google Calendar with our studio address. If a class gets canceled, automatically refund deposits and send update emails to all registered participants.
@@ -223,7 +223,7 @@ I run a yoga studio with 4 instructors and need clients to book classes online a
 
 ### Personal Training Client Portal
 
-**Genesis Prompt:**
+**Taskade Genesis Prompt:**
 
 ```
 I'm a personal trainer and need clients to schedule sessions, track their progress, and submit weekly check-ins. Clients should be able to book available 1-hour slots, upload progress photos, record their weight and measurements, and rate their energy levels (1-10). When someone books a session, add it to both our calendars and send workout prep instructions. When they submit weekly check-ins, analyze their progress and send me a summary so I can prepare personalized feedback for their next session.
@@ -241,7 +241,7 @@ I'm a personal trainer and need clients to schedule sessions, track their progre
 
 ### Inventory Management & Reorder System
 
-**Genesis Prompt:**
+**Taskade Genesis Prompt:**
 
 ```
 I run a boutique clothing store and need to track inventory levels and automate reordering. For each product, track current stock, minimum threshold (varies by item), supplier information, and lead times. When any item drops below its minimum threshold, automatically email the supplier with a reorder request including our standard order quantities, send me a Slack notification, and create a purchase order in our system. Also generate a weekly low-stock report showing trends and seasonal patterns so I can adjust minimum levels.
@@ -255,7 +255,7 @@ I run a boutique clothing store and need to track inventory levels and automate 
 
 ### Customer Loyalty Program
 
-**Genesis Prompt:**
+**Taskade Genesis Prompt:**
 
 ```
 I need a customer loyalty system for my coffee shop where customers earn points for purchases and can redeem rewards. Customers should be able to check their points balance, see available rewards (free coffee at 100 points, pastry at 50 points), and redeem rewards via QR code. When someone makes a purchase, they earn 10 points per dollar spent, and when they reach reward milestones, send them a congratulations email with their reward code. Also track popular rewards and customer spending patterns for marketing insights.
@@ -273,7 +273,7 @@ I need a customer loyalty system for my coffee shop where customers earn points 
 
 ### Client Proposal Request System
 
-**Genesis Prompt:**
+**Taskade Genesis Prompt:**
 
 ```
 I'm a marketing consultant and need potential clients to request proposals through my website. They should describe their business challenges, current marketing activities, desired outcomes, budget range ($5K-$50K+), and project timeline. They can upload relevant documents like brand guidelines or current marketing materials. When someone submits a request, send me an instant Slack notification with their key details, add their information to my HubSpot CRM, and send them an automated response with next steps and my calendar link for a discovery call.
@@ -335,7 +335,7 @@ I want to [HOW YOU'LL USE THE DATA] so I can [BUSINESS OUTCOME].
 
 ### Taskade Featured Apps
 
-See what Taskade itself built with Genesis:
+See what Taskade itself built with Taskade Genesis:
 
 | App                                                                                       | Description                                  |
 | ----------------------------------------------------------------------------------------- | -------------------------------------------- |
@@ -345,7 +345,7 @@ See what Taskade itself built with Genesis:
 
 ***
 
-**Ready to build your own app?** [**Start with Genesis →**](https://www.taskade.com)
+**Ready to build your own app?** [**Start with Taskade Genesis →**](https://www.taskade.com)
 
 [**Browse Community Apps →**](https://www.taskade.com/community) | [**Fork a Template →**](https://www.taskade.com/templates)
 

--- a/genesis-living-system-builder/genesis/getting-started.md
+++ b/genesis-living-system-builder/genesis/getting-started.md
@@ -6,7 +6,7 @@
 
 ## What is Taskade Genesis?
 
-Genesis turns a single prompt into a working app.
+Taskade Genesis turns a single prompt into a working app.
 
 It creates the UI and connects it to your workspace.
 
@@ -26,12 +26,12 @@ Start with [Workspace DNA](../../genesis-living-system-builder/genesis/workspace
 
 ### What You Can Build
 
-By the end of this guide, you'll have built and published a fully functional app. It can be a client portal, tracker, or dashboard. The only limitation is your imagination. Genesis handles the technical complexity, you focus on business value.
+By the end of this guide, you'll have built and published a fully functional app. It can be a client portal, tracker, or dashboard. The only limitation is your imagination. Taskade Genesis handles the technical complexity, you focus on business value.
 
 ### What You'll Learn
 
 * How to turn business problems into app descriptions
-* How to use Genesis to build complete applications
+* How to use Taskade Genesis to build complete applications
 * How to test and refine your app
 * How to share and use your app with customers or team members
 
@@ -39,7 +39,7 @@ By the end of this guide, you'll have built and published a fully functional app
 
 ## Step 1: Identify Your Business Problem (1 minute)
 
-Start by thinking about something in your business that could work better. Common problems Genesis solves:
+Start by thinking about something in your business that could work better. Common problems Taskade Genesis solves:
 
 ### **Customer Frustrations**
 
@@ -115,25 +115,25 @@ I'm a business consultant and need potential clients to request proposals throug
 
 ## Step 3: Build Your App with Genesis (1 minute)
 
-Now the magic happens - Genesis turns your description into a working app.
+Now the magic happens - Taskade Genesis turns your description into a working app.
 
 ### **Access Genesis**
 
 1. **Log into Taskade** at [taskade.com/create](https://www.taskade.com/create)
 2. **Navigate to your workspace** (create one if you don't have it)
 3. **Look for the AI prompt box** at the top of your workspace
-4. **Click "Create with AI"** or the Genesis icon
+4. **Click "Create with AI"** or the Taskade Genesis icon
 
 ### **Generate Your App**
 
 1. **Paste your description** into the prompt box
 2. **Click "Generate"** or press Enter
-3. **Watch Genesis work** - it will show you progress as it builds
+3. **Watch Taskade Genesis work** - it will show you progress as it builds
 4. **Wait 30-90 seconds** for your complete app to appear
 
 ### **What Genesis Creates**
 
-While you wait, Genesis is building all four components of your app:
+While you wait, Taskade Genesis is building all four components of your app:
 
 * **📊 Database** - Smart storage for all your business data
 * **🤖 AI Assistant** - Learns your business and helps users
@@ -144,11 +144,11 @@ While you wait, Genesis is building all four components of your app:
 
 ## Step 3.5: Add Context Files (Optional - 30 seconds)
 
-**Supercharge your app with reference materials.** Genesis can analyze uploaded files to better understand your brand, requirements, and design preferences.
+**Supercharge your app with reference materials.** Taskade Genesis can analyze uploaded files to better understand your brand, requirements, and design preferences.
 
 ### **Why Add Context?**
 
-Genesis becomes significantly more powerful when you provide reference materials:
+Taskade Genesis becomes significantly more powerful when you provide reference materials:
 
 * **🎨 Brand Consistency** - Upload logos, color palettes, and style guides
 * **📋 Form Examples** - Share existing forms or data structures
@@ -210,14 +210,14 @@ Your app is ready! Now test it thoroughly before sharing with others.
 
 * **No notifications received?** Check your email/Slack integration settings
 * **Form looks wrong?** Describe the visual changes you want
-* **Missing fields?** Tell Genesis what additional information you need
+* **Missing fields?** Tell Taskade Genesis what additional information you need
 * **Wrong automation timing?** Specify exactly when actions should happen
 
 ***
 
 ## Step 5: Perfect Your App (30 seconds)
 
-Need adjustments? Genesis makes changes instantly through conversation.
+Need adjustments? Taskade Genesis makes changes instantly through conversation.
 
 ### **Common Refinements**
 
@@ -249,7 +249,7 @@ Need adjustments? Genesis makes changes instantly through conversation.
 
 1. **Describe what you want to change** in plain English
 2. **Click "Update App"** or similar button
-3. **Wait for Genesis to implement** your changes (usually 10-30 seconds)
+3. **Wait for Taskade Genesis to implement** your changes (usually 10-30 seconds)
 4. **Test the changes** to make sure they work as expected
 
 ***
@@ -259,7 +259,7 @@ Need adjustments? Genesis makes changes instantly through conversation.
 Your app is ready for the real world! You've built something that solves a real business problem, and now it's time to put it in front of actual users.
 
 {% hint style="warning" %}
-**Secure your API keys before publishing.** If your app calls external APIs, store credentials in the Secrets vault (space **Settings → Secrets**) and route calls through the outbound proxy so keys never ship in client code. Genesis blocks publish if hardcoded secrets are detected. See [App Secrets](../space-apps-guide/app-secrets.md) for setup steps.
+**Secure your API keys before publishing.** If your app calls external APIs, store credentials in the Secrets vault (space **Settings → Secrets**) and route calls through the outbound proxy so keys never ship in client code. Taskade Genesis blocks publish if hardcoded secrets are detected. See [App Secrets](../space-apps-guide/app-secrets.md) for setup steps.
 {% endhint %}
 
 ### **Publishing Options**
@@ -268,7 +268,7 @@ Your app is ready for the real world! You've built something that solves a real 
 2. **Custom Domain**: Publish under your branded domain (e.g., `app.yourcompany.com`)
 3. **Share with Community**: Publish to the global Taskade marketplace for others to discover and fork
 4. **Public Link**: Get a shareable URL for external users
-5. **Genesis App MCP (Beta)**: Expose your app as an MCP server so AI agents and external tools can call it programmatically — see [Genesis App MCP (Beta)](../../apis-living-system-development/genesis-app-mcp.md)
+5. **Taskade Genesis App MCP (Beta)**: Expose your app as an MCP server so AI agents and external tools can call it programmatically — see [Taskade Genesis App MCP (Beta)](../../apis-living-system-development/genesis-app-mcp.md)
 
 ### **Getting It Live**
 
@@ -306,39 +306,39 @@ Share your success story and get featured:
 
 ***
 
-## Real Success Stories
+## What people build in their first 5 minutes
 
-Here are what other users built in their first 5 minutes:
+A few common starting points — each began as a single plain-English prompt:
 
-### **Maria - Restaurant Feedback System**
+### Restaurant feedback system
 
-**Problem:** "Customers left reviews on Google but we saw them too late to respond to problems."
+**Problem:** Reviews landed on Google too late to act on.
 
-**Genesis Prompt:** "I need customers to rate their dining experience and leave comments, with instant Slack alerts for any rating below 4 stars."
+**Prompt:** "I need customers to rate their dining experience and leave comments, with instant Slack alerts for any rating below 4 stars."
 
-**Result:** "I get immediate notifications about unhappy customers and can follow up personally. Our Google reviews improved from 3.8 to 4.6 stars in two months!"
+**What you get:** A live feedback form, a place to triage responses, and real-time alerts so low ratings surface immediately instead of days later.
 
-### **David - Yoga Studio Booking**
+### Yoga studio booking
 
-**Problem:** "Appointment booking was all phone calls and double-bookings were common."
+**Problem:** Booking was all phone calls, and double-bookings were common.
 
-**Genesis Prompt:** "I need clients to book yoga classes online, pay deposits, and get calendar invites, with automatic confirmations."
+**Prompt:** "I need clients to book yoga classes online, pay deposits, and get calendar invites, with automatic confirmations."
 
-**Result:** "Saves me 2 hours every day. No more double-bookings, and I get paid in advance. Clients love the convenience!"
+**What you get:** An online booking flow with deposits, calendar invites, and automatic confirmations — no more phone-tag or double-bookings.
 
-### **Sarah - Inventory Alerts**
+### Inventory alerts
 
-**Problem:** "I never knew when products were running low until customers complained they were out of stock."
+**Problem:** Stock ran low before anyone noticed.
 
-**Genesis Prompt:** "I need to track inventory levels and get email alerts when items drop below 10 units, with automatic reorder suggestions."
+**Prompt:** "I need to track inventory levels and get email alerts when items drop below 10 units, with automatic reorder suggestions."
 
-**Result:** "Haven't had a stockout in 6 months! My supplier gets orders automatically and I can focus on sales instead of counting inventory."
+**What you get:** A stock tracker that emails you before items run out and suggests reorders automatically.
 
 ***
 
 ## What's Next?
 
-Congratulations! You've built your first Genesis app. Here's how to take it further, in two phases.
+Congratulations! You've built your first Taskade Genesis app. Here's how to take it further, in two phases.
 
 ### **Phase 1 — Build**
 
@@ -389,7 +389,7 @@ Keep this handy for your next app:
 
 1. **Identify problem** - What frustrates you or your customers?
 2. **Write description** - WHO + WHAT + AUTOMATIC ACTIONS
-3. **Build with Genesis** - Paste prompt and click Generate
+3. **Build with Taskade Genesis** - Paste prompt and click Generate
 4. **Test thoroughly** - Try all features as real user would
 5. **Perfect & share** - Make adjustments and go live
 

--- a/genesis-living-system-builder/genesis/github-import-export.md
+++ b/genesis-living-system-builder/genesis/github-import-export.md
@@ -1,6 +1,6 @@
 # GitHub Import & Export
 
-Bring Genesis apps in from GitHub repositories and push your apps back to GitHub with branch-and-PR workflows. Two-way sync turns every Genesis app into a portable, version-controlled kit.
+Bring Taskade Genesis apps in from GitHub repositories and push your apps back to GitHub with branch-and-PR workflows. Two-way sync turns every Genesis app into a portable, version-controlled kit.
 
 ***
 

--- a/genesis-living-system-builder/genesis/how-genesis-works.md
+++ b/genesis-living-system-builder/genesis/how-genesis-works.md
@@ -5,9 +5,9 @@
 ## Table of Contents
 
 - [Overview](#overview)
-- [What Is Genesis?](#what-is-genesis)
+- [What Is Taskade Genesis?](#what-is-genesis)
 - [What You Can Build](#what-you-can-build)
-- [What Makes Genesis Different](#what-makes-genesis-different)
+- [What Makes Taskade Genesis Different](#what-makes-genesis-different)
 - [The Tree of Life Architecture](#the-tree-of-life-architecture)
   - [Memory: Projects & Databases](#memory-projects-and-databases)
   - [Intelligence: Custom AI Agents](#intelligence-custom-ai-agents)
@@ -31,13 +31,13 @@ This guide explains the core architecture behind **Taskade Genesis** — the AI 
 - **EVE:** How Taskade's unified AI system connects everything together.
 - **Intelligence Score:** How your workspace earns a 0–100 score across 5 maturity tiers.
 
-> **New to Genesis?** Start with [Create Your First App](./getting-started.md) for a hands-on walkthrough, or jump straight in and build your first app with [Taskade Genesis](https://www.taskade.com/create).
+> **New to Taskade Genesis?** Start with [Create Your First App](./getting-started.md) for a hands-on walkthrough, or jump straight in and build your first app with [Taskade Genesis](https://www.taskade.com/create).
 
 ---
 
 ## What Is Genesis?
 
-Genesis is Taskade's breakthrough AI platform that transforms natural language descriptions into **complete, working business applications** in minutes — not mockups, not prototypes, but fully functional software.
+Taskade Genesis is Taskade's breakthrough AI platform that transforms natural language descriptions into **complete, working business applications** in minutes — not mockups, not prototypes, but fully functional software.
 
 A single prompt gives you:
 
@@ -53,15 +53,15 @@ A single prompt gives you:
 | **Version Control** | Full commit history with one-click restore to any previous version |
 | **Publishing** | Instant deployment with shareable links, custom domains, and community gallery |
 
-> **Genesis hint:** Your AI credits power app creation. Different models have different credit costs — see [Taskade AI Credits](https://www.taskade.com/learn/agents/ai-usage) for details.
+> **Taskade Genesis hint:** Your AI credits power app creation. Different models have different credit costs — see [Taskade AI Credits](https://www.taskade.com/learn/agents/ai-usage) for details.
 
 ---
 
 ## What You Can Build
 
-Genesis doesn't care what industry you're in. You describe the problem; it builds the solution.
+Taskade Genesis doesn't care what industry you're in. You describe the problem; it builds the solution.
 
-| What You Ask For | What Genesis Builds | Powered By Your DNA |
+| What You Ask For | What Taskade Genesis Builds | Powered By Your DNA |
 |---|---|---|
 | "Build a customer feedback app" | Ratings system, sentiment analysis, photo uploads, manager alerts, follow-up workflows | Your service standards, past feedback patterns, resolution strategies |
 | "Create a booking system" | Real-time scheduling, payment processing, automated confirmations, customer history, staff optimization | Your services, pricing, availability rules, customer preferences |
@@ -75,7 +75,7 @@ Genesis doesn't care what industry you're in. You describe the problem; it build
 
 ## What Makes Genesis Different
 
-Unlike every other app builder, Genesis doesn't start with empty templates or generic forms. It reaches into your **existing Workspace DNA**:
+Unlike every other app builder, Taskade Genesis doesn't start with empty templates or generic forms. It reaches into your **existing Workspace DNA**:
 
 | Traditional App Builders | Taskade Genesis |
 |---|---|
@@ -98,7 +98,7 @@ Unlike every other app builder, Genesis doesn't start with empty templates or ge
 
 ## The Tree of Life Architecture
 
-At the core of every Genesis app lies the **Tree of Life** — a continuous cycle of three interconnected systems that never stop learning.
+At the core of every Taskade Genesis app lies the **Tree of Life** — a continuous cycle of three interconnected systems that never stop learning.
 
 ```
         +------------------+
@@ -127,9 +127,9 @@ At the core of every Genesis app lies the **Tree of Life** — a continuous cycl
 
 ### Memory: Projects & Databases
 
-In Genesis, "Memory" means **living context** — information that maintains relationships, accumulates meaning over time, and actively participates in intelligence.
+In Taskade Genesis, "Memory" means **living context** — information that maintains relationships, accumulates meaning over time, and actively participates in intelligence.
 
-| App Type | Memory Structure Genesis Creates |
+| App Type | Memory Structure Taskade Genesis Creates |
 |---|---|
 | **Customer Feedback** | Feedback database with rating fields, contact storage, photo attachments, follow-up tracking, resolution history |
 | **Booking System** | Appointment database, client profiles, service catalog, staff schedules, payment records |
@@ -187,7 +187,7 @@ Execution means **intelligent automation workflows** — the nervous system that
 
 ## The Self-Reinforcing Feedback Loop
 
-Every action in your Genesis app generates results that flow back into your workspace memory, creating a **self-reinforcing intelligence loop**.
+Every action in your Taskade Genesis app generates results that flow back into your workspace memory, creating a **self-reinforcing intelligence loop**.
 
 | Action Type | Memory Created | Your Workspace Learns |
 |---|---|---|
@@ -210,7 +210,7 @@ Every action in your Genesis app generates results that flow back into your work
 
 ## Workspace Intelligence Score
 
-Every Genesis workspace earns an **Intelligence Score** from 0–100, calculated from your three DNA pillars:
+Every Taskade Genesis workspace earns an **Intelligence Score** from 0–100, calculated from your three DNA pillars:
 
 | Component | Points Each | Max Items Scored | Max Points |
 |---|---|---|---|
@@ -254,7 +254,7 @@ When you interact with Taskade, EVE:
 
 ### The Bicameral Partnership
 
-Genesis creates a cognitive partnership where:
+Taskade Genesis creates a cognitive partnership where:
 - **Your mind** contributes intent, goals, domain knowledge, and creative vision
 - **EVE's intelligence** handles technical implementation, pattern recognition, and optimization
 - **Together**, you create something neither could build alone
@@ -265,7 +265,7 @@ Genesis creates a cognitive partnership where:
 
 | Action | Example | What Happens |
 |---|---|---|
-| **Build Genesis Apps** | "Build a customer feedback app with sentiment analysis" | Generates complete app with projects, agents, and automations |
+| **Build Taskade Genesis Apps** | "Build a customer feedback app with sentiment analysis" | Generates complete app with projects, agents, and automations |
 | **Create AI Agents** | "Create an agent trained on our product documentation" | Creates agent, indexes docs, configures knowledge base |
 | **Configure Automations** | "When a task is complete, send a Slack notification" | Creates automation with trigger, action, and conditions |
 | **Manage Projects** | "Create a project for Q1 marketing campaigns" | Creates structured project with relevant sections |
@@ -280,11 +280,11 @@ Genesis creates a cognitive partnership where:
 
 ## Kits & Bundles: Package Your Entire Workspace
 
-Genesis workspaces can be packaged as **Bundles (Kits)** — installable packages that include everything:
+Taskade Genesis workspaces can be packaged as **Bundles (Kits)** — installable packages that include everything:
 
 | Bundle Component | Included | Description |
 |---|---|---|
-| **Genesis Apps** | Yes | Full app with UI, code, and configuration |
+| **Taskade Genesis Apps** | Yes | Full app with UI, code, and configuration |
 | **Projects & Databases** | Yes | Data structures and sample records |
 | **AI Agents** | Yes | Agent configs, personas, knowledge references |
 | **Automation Flows** | Yes | Workflow definitions and triggers |
@@ -317,7 +317,7 @@ Your workspace DNA organizes memory into 5 psychological layers:
 | **Navigation Memory** | Structural organization | Workspace hierarchy, project categories |
 | **Learning Memory** | Insights and patterns accumulated over time | Performance trends, customer behavior patterns |
 
-> AI agents and Genesis apps access all 5 memory layers to provide contextual, accurate responses.
+> AI agents and Taskade Genesis apps access all 5 memory layers to provide contextual, accurate responses.
 
 ---
 
@@ -345,7 +345,7 @@ You now understand the DNA of your workspace. Choose your path:
 
 | Guide | What You'll Learn |
 |---|---|
-| [Adding Genesis Context](./adding-context.md) | Upload files and data to enrich app intelligence |
+| [Adding Taskade Genesis Context](./adding-context.md) | Upload files and data to enrich app intelligence |
 | [Publish and Clone Your Apps](../community-and-sharing/publish-and-clone.md) | Deploy, share, and distribute your apps |
 | [Taskade AI Credits](../../account-management/credits-and-billing.md) | Understand credits, models, and usage |
 | [Build on Taskade (Developer Hub)](../../apis-living-system-development/developer-home.md) | APIs, SDKs, and MCP for programmatic access |

--- a/genesis-living-system-builder/genesis/mcp-connectors.md
+++ b/genesis-living-system-builder/genesis/mcp-connectors.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Connect your Genesis apps and AI agents to 31+ external services using MCP
+  Connect your Taskade Genesis apps and AI agents to 31+ external services using MCP
   (Model Context Protocol) — the universal standard for AI tool integration.
 ---
 

--- a/genesis-living-system-builder/genesis/prompt-guide.md
+++ b/genesis-living-system-builder/genesis/prompt-guide.md
@@ -6,7 +6,7 @@
 
 AI prompts are the key to building exactly what you envision. A prompt is simply the description of what you want to build — think of it as explaining your app idea to a colleague who can build it for you. The clearer your explanation, the better your app turns out.
 
-This guide covers **12 proven principles** for writing effective Genesis prompts.
+This guide covers **12 proven principles** for writing effective Taskade Genesis prompts.
 
 > **Workspace DNA hint:** The better your prompts, the richer your workspace DNA becomes. Every app you build adds to your [Intelligence Score](./how-genesis-works.md#workspace-intelligence-score) and makes future apps smarter.
 

--- a/genesis-living-system-builder/genesis/version-history.md
+++ b/genesis-living-system-builder/genesis/version-history.md
@@ -17,7 +17,7 @@
 
 ## Overview
 
-Genesis **automatically tracks every change** to your apps. Every modification — from content edits to styling updates — creates a new version (commit) you can view, compare, and restore at any time. This gives you a complete safety net for experimentation and iteration.
+Taskade Genesis **automatically tracks every change** to your apps. Every modification — from content edits to styling updates — creates a new version (commit) you can view, compare, and restore at any time. This gives you a complete safety net for experimentation and iteration.
 
 > **Experiment freely:** Try bold changes knowing you can always roll back. See [A Maker's Guide to AI Prompts — Experiment](./prompt-guide.md#id-12.-experiment).
 

--- a/genesis-living-system-builder/genesis/workspace-dna.md
+++ b/genesis-living-system-builder/genesis/workspace-dna.md
@@ -1,7 +1,7 @@
 ---
 description: >-
   Understand the three-pillar architecture that powers every Taskade workspace
-  and Genesis app: Memory, Intelligence, and Execution.
+  and Taskade Genesis app: Memory, Intelligence, and Execution.
 ---
 
 # Workspace DNA

--- a/genesis-living-system-builder/run-your-business/README.md
+++ b/genesis-living-system-builder/run-your-business/README.md
@@ -8,14 +8,14 @@ description: >-
 
 **Describe your business in plain English and get a real, running app — then put it on your own domain with logins and run your operation on it.** No code. No sales call.
 
-Thousands of operators — consultants, clinics, realtors, agencies, construction and logistics teams — already run their day-to-day on a Genesis app. This track stitches the pieces into one path: **build → add your data → add logins → put it on your domain → go live.**
+Thousands of operators — consultants, clinics, realtors, agencies, construction and logistics teams — already run their day-to-day on a Taskade Genesis app. This track stitches the pieces into one path: **build → add your data → add logins → put it on your domain → go live.**
 
 ***
 
 ## Pick what you're building
 
 {% hint style="info" %}
-New to Genesis? Start with [Your first app in 5 minutes](../genesis/getting-started.md), then come back here to turn it into a business you run.
+New to Taskade Genesis? Start with [Your first app in 5 minutes](../genesis/getting-started.md), then come back here to turn it into a business you run.
 {% endhint %}
 
 | You want to… | Start here |
@@ -34,7 +34,7 @@ New to Genesis? Start with [Your first app in 5 minutes](../genesis/getting-star
 {% step %}
 #### Build it
 
-Describe the app you want to Genesis and iterate until it works. → [Getting started](../genesis/getting-started.md)
+Describe the app you want to Taskade Genesis and iterate until it works. → [Getting started](../genesis/getting-started.md)
 {% endstep %}
 
 {% step %}

--- a/genesis-living-system-builder/run-your-business/add-login-and-roles.md
+++ b/genesis-living-system-builder/run-your-business/add-login-and-roles.md
@@ -1,13 +1,13 @@
 ---
 description: >-
-  Add secure sign-in and access control to your Genesis app so the right people
+  Add secure sign-in and access control to your Taskade Genesis app so the right people
   see the right things — no code, no third-party auth provider.
 keywords: add login, access control, RBAC, app users, SSO, no-code
 ---
 
 # Add login and roles to your app
 
-Genesis apps can ship with real user accounts and secure sign-in built in, powered by [GenesisAuth](../community-and-sharing/genesis-auth.md). To add login, you don't configure anything — you describe the need when you build the app (for example, *"users can sign in to see their own dashboard"*), and Genesis wires up the sign-in component, session handling, and per-user data access automatically.
+Taskade Genesis apps can ship with real user accounts and secure sign-in built in, powered by [GenesisAuth](../community-and-sharing/genesis-auth.md). To add login, you don't configure anything — you describe the need when you build the app (for example, *"users can sign in to see their own dashboard"*), and Taskade Genesis wires up the sign-in component, session handling, and per-user data access automatically.
 
 {% hint style="success" %}
 **The short version:** Describe an app that needs accounts, and your app gets a working login screen. Then manage who gets in from the **App Users** tab in your app's settings.
@@ -39,11 +39,11 @@ The **App Users** tab is currently in Beta and rolling out across paid plans.
 
 You won't find a switch to flip — you ask for it in plain language.
 
-1. In Genesis, describe an app that needs accounts. Include phrases like *"a client portal where each client has their own dashboard"* or *"a members-only knowledge base."*
-2. Genesis generates the app **with the sign-in component already in place**.
+1. In Taskade Genesis, describe an app that needs accounts. Include phrases like *"a client portal where each client has their own dashboard"* or *"a members-only knowledge base."*
+2. Taskade Genesis generates the app **with the sign-in component already in place**.
 3. Open your app's settings and go to the **App Users** tab to invite people, suspend access, or remove accounts.
 
-If your first prompt didn't add login, you can ask Genesis to *"add sign-in for users"* later while editing the app.
+If your first prompt didn't add login, you can ask Taskade Genesis to *"add sign-in for users"* later while editing the app.
 
 For the full walkthrough — the App Users tab, Workspace SSO, custom-domain sign-in, and the security model — see the source page:
 

--- a/genesis-living-system-builder/run-your-business/build-a-client-portal.md
+++ b/genesis-living-system-builder/run-your-business/build-a-client-portal.md
@@ -6,7 +6,7 @@ description: >-
 
 # Build a client or member portal in 10 minutes
 
-**You describe the portal you want. Genesis builds it. Each client logs in and sees only their own record — their projects, their files, their status — and nothing belonging to anyone else.**
+**You describe the portal you want. Taskade Genesis builds it. Each client logs in and sees only their own record — their projects, their files, their status — and nothing belonging to anyone else.**
 
 No code. No separate login service to wire up. No spreadsheets to share by hand. By the end of this guide you'll have a working, branded portal at your own web address that you can hand to your first client.
 
@@ -27,7 +27,7 @@ No code. No separate login service to wire up. No spreadsheets to share by hand.
 {% step %}
 ### Describe the portal
 
-Open Genesis and describe what you want in plain English — who logs in, what they see, and what stays private. Genesis turns that description into a working app with a database and screens already wired together.
+Open Taskade Genesis and describe what you want in plain English — who logs in, what they see, and what stays private. Taskade Genesis turns that description into a working app with a database and screens already wired together.
 
 Start with a prompt like this and edit the bracketed parts for your business:
 
@@ -39,18 +39,18 @@ each project. Clients can never see other clients' information. I sign in as
 the owner and can see and manage every client from one admin view.
 ```
 
-The more specific you are about *what each client sees*, the better the first build. New to Genesis? Walk through [Getting Started](../genesis/getting-started.md) first.
+The more specific you are about *what each client sees*, the better the first build. New to Taskade Genesis? Walk through [Getting Started](../genesis/getting-started.md) first.
 {% endstep %}
 
 {% step %}
 ### Give each client their own login
 
-A portal needs real sign-in so the right person sees the right thing. When your prompt mentions per-client accounts, Genesis adds a secure login automatically — no auth provider to set up.
+A portal needs real sign-in so the right person sees the right thing. When your prompt mentions per-client accounts, Taskade Genesis adds a secure login automatically — no auth provider to set up.
 
 You manage everyone from the **App Users** tab: invite clients by email, suspend access when an engagement ends, and remove accounts you no longer need. See [GenesisAuth — add login & roles](../community-and-sharing/genesis-auth.md) for the full picture.
 
 {% hint style="success" %}
-If your first build didn't add sign-in, just tell Genesis *"add sign-in so each client has their own account"* while editing the app.
+If your first build didn't add sign-in, just tell Taskade Genesis *"add sign-in so each client has their own account"* while editing the app.
 {% endhint %}
 {% endstep %}
 
@@ -59,7 +59,7 @@ If your first build didn't add sign-in, just tell Genesis *"add sign-in so each 
 
 This is what makes it a *portal* instead of a shared page: every client sees only their own data. Conceptually, each record in your portal is tied to the client it belongs to, and the login decides which records that person can open. Client A signs in and sees Client A's projects; Client B never sees them.
 
-You don't configure this by hand — you describe it. Phrases like *"each client sees only their own projects and documents"* tell Genesis to scope the data per user. To shape what's stored and shown, see how [Projects & Databases](../workspaces/projects-databases.md) hold your records, and how [GenesisAuth](../community-and-sharing/genesis-auth.md) ties each record to the signed-in client.
+You don't configure this by hand — you describe it. Phrases like *"each client sees only their own projects and documents"* tell Taskade Genesis to scope the data per user. To shape what's stored and shown, see how [Projects & Databases](../workspaces/projects-databases.md) hold your records, and how [GenesisAuth](../community-and-sharing/genesis-auth.md) ties each record to the signed-in client.
 
 {% hint style="warning" %}
 Always test isolation before going live: sign in as a test client and confirm you can't see anyone else's records.
@@ -79,7 +79,7 @@ Follow [Custom Domains & Branding](../space-apps-guide/custom-domains.md) to con
 
 You're ready to go live. Open the **App Users** tab and invite your first client by email — they'll get a link, set a password, and land directly on their own dashboard.
 
-Before you send invites, run the [Go-live checklist](./go-live-checklist.md) so logins, per-client access, and your domain are all confirmed. Then start small: invite one trusted client, watch them use it, and refine the wording or layout by describing the change to Genesis.
+Before you send invites, run the [Go-live checklist](./go-live-checklist.md) so logins, per-client access, and your domain are all confirmed. Then start small: invite one trusted client, watch them use it, and refine the wording or layout by describing the change to Taskade Genesis.
 {% endstep %}
 {% endstepper %}
 
@@ -91,4 +91,4 @@ Before you send invites, run the [Go-live checklist](./go-live-checklist.md) so 
 * [Go-live checklist](./go-live-checklist.md) — confirm access, branding, and your domain before inviting clients.
 * [GenesisAuth](../community-and-sharing/genesis-auth.md) — manage clients in the App Users tab.
 * [Custom Domains & Branding](../space-apps-guide/custom-domains.md) — host the portal at `portal.yourbrand.com`.
-* [Getting Started with Genesis](../genesis/getting-started.md) — how describing an app turns into a working one.
+* [Getting Started with Taskade Genesis](../genesis/getting-started.md) — how describing an app turns into a working one.

--- a/genesis-living-system-builder/run-your-business/build-an-ops-dashboard.md
+++ b/genesis-living-system-builder/run-your-business/build-an-ops-dashboard.md
@@ -1,14 +1,14 @@
 ---
 description: >-
   Build an internal ops dashboard, CRM, or pipeline your whole team logs into —
-  describe it to Genesis, connect live workspace data, and let people in with the
+  describe it to Taskade Genesis, connect live workspace data, and let people in with the
   Taskade identity they already have.
 keywords: ops dashboard, internal tool, CRM, pipeline, no-code
 ---
 
 # Build an internal ops dashboard your team runs on
 
-You don't need a developer to give your team one place to run the day. Describe the board, pipeline, or tracker you wish you had, and Genesis builds it on top of your live workspace data. Your team logs in with the Taskade identity they already use, sees the same up-to-date picture you do, and gets a daily summary in Slack or email — without anyone touching a spreadsheet on the side.
+You don't need a developer to give your team one place to run the day. Describe the board, pipeline, or tracker you wish you had, and Taskade Genesis builds it on top of your live workspace data. Your team logs in with the Taskade identity they already use, sees the same up-to-date picture you do, and gets a daily summary in Slack or email — without anyone touching a spreadsheet on the side.
 
 This is the **internal** counterpart to a client portal. Here the people logging in are your own crew, dispatchers, project managers, or coordinators — not your customers.
 
@@ -16,7 +16,7 @@ This is the **internal** counterpart to a client portal. Here the people logging
 {% step %}
 ### Describe your board or pipeline
 
-Open Genesis and tell it, in plain English, what your team needs to see and do every day. Name the stages, the fields you track, and the views you want. Genesis turns that one description into a working app — the UI, the database behind it, and the structure to keep it organized.
+Open Taskade Genesis and tell it, in plain English, what your team needs to see and do every day. Name the stages, the fields you track, and the views you want. Taskade Genesis turns that one description into a working app — the UI, the database behind it, and the structure to keep it organized.
 
 ```
 I run field operations for a construction company and need my project
@@ -28,13 +28,13 @@ columns and add notes and photos. I want a dashboard view that shows how
 many jobs sit in each stage so I can see where we're stuck at a glance.
 ```
 
-Start with one workflow you already run on whiteboards or spreadsheets. You can refine wording, add fields, or change views later just by asking. For the full describe-and-build loop, see [Getting Started with Genesis](../genesis/getting-started.md).
+Start with one workflow you already run on whiteboards or spreadsheets. You can refine wording, add fields, or change views later just by asking. For the full describe-and-build loop, see [Getting Started with Taskade Genesis](../genesis/getting-started.md).
 {% endstep %}
 
 {% step %}
 ### Connect live workspace data
 
-The board Genesis builds isn't a static mockup — it's backed by a real project database that acts as your **system of record**. Every job, lead, or shipment is a live record your team reads and updates in real time, and the same data feeds your dashboards, agents, and automations.
+The board Taskade Genesis builds isn't a static mockup — it's backed by a real project database that acts as your **system of record**. Every job, lead, or shipment is a live record your team reads and updates in real time, and the same data feeds your dashboards, agents, and automations.
 
 That means there's no separate spreadsheet to reconcile. When a manager moves a job to "Inspection," the dashboard counts update instantly for everyone. To understand how projects work as live databases — fields, views, relationships, and permissions — see [Projects & Databases](../workspaces/projects-databases.md).
 {% endstep %}
@@ -52,7 +52,7 @@ This is the key distinction for an internal dashboard: you invite people to the 
 
 Give your team a heads-up without anyone having to open the app first thing. Add a scheduled automation that builds a short summary — open jobs, overdue items, what moved yesterday — and sends it to a Slack channel or by email every morning.
 
-Describe it the same way you described the board: tell Genesis what to include and when to send it. The automation reads straight from your live project data, so the digest is always current. See [Automations](../automation/README.md) to build the scheduled summary.
+Describe it the same way you described the board: tell Taskade Genesis what to include and when to send it. The automation reads straight from your live project data, so the digest is always current. See [Automations](../automation/README.md) to build the scheduled summary.
 {% endstep %}
 {% endstepper %}
 
@@ -63,7 +63,7 @@ Describe it the same way you described the board: tell Genesis what to include a
 
 **External:** clients and customers sign in as **App Users** — separate accounts scoped to the app, not members of your workspace. Use that model when you're building a client-facing portal. See [Build a client portal](./build-a-client-portal.md).
 
-Same Genesis app, two different doors. Choose based on who's logging in.
+Same Taskade Genesis app, two different doors. Choose based on who's logging in.
 {% endhint %}
 
 ## Next steps

--- a/genesis-living-system-builder/run-your-business/from-idea-to-live-business.md
+++ b/genesis-living-system-builder/run-your-business/from-idea-to-live-business.md
@@ -12,13 +12,13 @@ You have a business problem and an idea for an app that fixes it. This guide is 
 
 ## Step 1 — Describe your app to Genesis
 
-Start with the problem, not the software. Tell Genesis what you do, who will use the app, and what should happen when they use it. EVE turns that description into a working app — the screens, the data behind them, and the logic that connects them. This is where your idea becomes something you can click. You build by describing changes in plain English, so refining is just another sentence.
+Start with the problem, not the software. Tell Taskade Genesis what you do, who will use the app, and what should happen when they use it. EVE turns that description into a working app — the screens, the data behind them, and the logic that connects them. This is where your idea becomes something you can click. You build by describing changes in plain English, so refining is just another sentence.
 
-→ Full guide: [Getting Started with Genesis](../genesis/getting-started.md)
+→ Full guide: [Getting Started with Taskade Genesis](../genesis/getting-started.md)
 
 ## Step 2 — Shape your data into a system of record
 
-Every real business app remembers things — customers, bookings, orders, requests. Genesis creates the databases your app needs automatically, and this is where you shape them: name your fields clearly, link related records, and choose the view (table, board, calendar, and more) that matches how you actually work. Get this right and your app stops being a form and becomes a single source of truth your whole business runs on.
+Every real business app remembers things — customers, bookings, orders, requests. Taskade Genesis creates the databases your app needs automatically, and this is where you shape them: name your fields clearly, link related records, and choose the view (table, board, calendar, and more) that matches how you actually work. Get this right and your app stops being a form and becomes a single source of truth your whole business runs on.
 
 → Full guide: [Projects & Databases](../workspaces/projects-databases.md)
 
@@ -50,5 +50,5 @@ Your app runs on AI, and AI runs on credits. Before launch, match your plan and 
 
 * [Go-Live Checklist](./go-live-checklist.md) — final pre-launch pass before you share the link
 * [Add Login & Roles](./add-login-and-roles.md) — go deeper on accounts and access control
-* [Getting Started with Genesis](../genesis/getting-started.md) — revisit Step 1 to refine your app
+* [Getting Started with Taskade Genesis](../genesis/getting-started.md) — revisit Step 1 to refine your app
 * [Custom Domains & Branding](../space-apps-guide/custom-domains.md) — polish your branded launch

--- a/genesis-living-system-builder/run-your-business/go-live-checklist.md
+++ b/genesis-living-system-builder/run-your-business/go-live-checklist.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  A go-live checklist for launching your Genesis business app to real users —
+  A go-live checklist for launching your Taskade Genesis business app to real users —
   secrets, logins, your domain, and credits, all in one place.
 ---
 
@@ -13,7 +13,7 @@ You described an app, shaped your data, and it works. Before you put it in front
 ### 🔐 Security
 
 * [ ] **Secrets are vaulted, not hardcoded.** Any API key, token, or password your app uses lives in the secret vault — never pasted into a prompt or page. → [App Secrets](../space-apps-guide/app-secrets.md)
-* [ ] **The publish guard passed.** Genesis blocks publishing if it spots a hardcoded credential; resolve any warning before launch. → [App Secrets](../space-apps-guide/app-secrets.md)
+* [ ] **The publish guard passed.** Taskade Genesis blocks publishing if it spots a hardcoded credential; resolve any warning before launch. → [App Secrets](../space-apps-guide/app-secrets.md)
 
 ### 👤 Access & data
 

--- a/genesis-living-system-builder/space-apps-guide/README.md
+++ b/genesis-living-system-builder/space-apps-guide/README.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Publish Genesis apps as real products — add custom domains, branding, advanced features, and styling to turn your workspace into a live application.
+  Publish Taskade Genesis apps as real products — add custom domains, branding, advanced features, and styling to turn your workspace into a live application.
 ---
 
 # Space Apps: Living Systems

--- a/genesis-living-system-builder/space-apps-guide/advanced-features.md
+++ b/genesis-living-system-builder/space-apps-guide/advanced-features.md
@@ -1,6 +1,6 @@
 # Advanced Features
 
-Ready to take your Genesis app to the next level? These powerful features help you build even smarter and more capable applications. No coding required—just plain English descriptions of what you want!
+Ready to take your Taskade Genesis app to the next level? These powerful features help you build even smarter and more capable applications. No coding required—just plain English descriptions of what you want!
 
 ## How Genesis Gets So Smart
 

--- a/genesis-living-system-builder/space-apps-guide/app-secrets.md
+++ b/genesis-living-system-builder/space-apps-guide/app-secrets.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Store API keys and tokens in a per-space vault, then reference them safely in Genesis app code — real credentials never leave the server.
+  Store API keys and tokens in a per-space vault, then reference them safely in Taskade Genesis app code — real credentials never leave the server.
 ---
 
 # App Secrets & External API Calls

--- a/genesis-living-system-builder/space-apps-guide/custom-domains.md
+++ b/genesis-living-system-builder/space-apps-guide/custom-domains.md
@@ -1,5 +1,5 @@
 ---
-description: Connect your own branded domain to a published Genesis app.
+description: Connect your own branded domain to a published Taskade Genesis app.
 ---
 
 # Custom Domains & Branding

--- a/genesis-living-system-builder/space-apps-guide/genesis-prompt-library.md
+++ b/genesis-living-system-builder/space-apps-guide/genesis-prompt-library.md
@@ -1,6 +1,6 @@
 # Intelligent Prompt Library
 
-Master Genesis with proven prompts organized by business function. Copy, paste, and customize these prompts to build your perfect app in minutes.
+Master Taskade Genesis with proven prompts organized by business function. Copy, paste, and customize these prompts to build your perfect app in minutes.
 
 ## 📚 The Complete Guide to Writing Effective Genesis Prompts
 

--- a/genesis-living-system-builder/workspaces/editing-formatting.md
+++ b/genesis-living-system-builder/workspaces/editing-formatting.md
@@ -21,7 +21,7 @@
 
 Every Taskade project is a collection of **tasks** — structured like bullet points that can be nested into sub-tasks. You can format, style, reorder, and enhance tasks with add-ons like due dates, assignees, comments, timers, and custom fields.
 
-> **Genesis hint:** Genesis apps use these same formatting and structuring capabilities in their project databases. Understanding formatting helps you build better apps.
+> **Taskade Genesis hint:** Genesis apps use these same formatting and structuring capabilities in their project databases. Understanding formatting helps you build better apps.
 
 ---
 

--- a/genesis-living-system-builder/workspaces/embed.md
+++ b/genesis-living-system-builder/workspaces/embed.md
@@ -8,7 +8,7 @@
 - [Embed a Project](#embed-a-project)
 - [Embed Settings](#embed-settings)
 - [Supported Embed Sources (In Taskade)](#supported-embed-sources-in-taskade)
-- [Embed Genesis Apps](#embed-genesis-apps)
+- [Embed Taskade Genesis Apps](#embed-genesis-apps)
 - [What's Next](#whats-next)
 
 ---

--- a/genesis-living-system-builder/workspaces/import.md
+++ b/genesis-living-system-builder/workspaces/import.md
@@ -96,7 +96,7 @@ Create `.md` files directly in Taskade and use them as project sources:
 | 4 | Paste Markdown-formatted text |
 | 5 | The `.md` file is created and added to the **Media Tab** |
 
-> Created Markdown documents can be used as agent knowledge, project context, or Genesis app context.
+> Created Markdown documents can be used as agent knowledge, project context, or Taskade Genesis app context.
 
 ---
 

--- a/genesis-living-system-builder/workspaces/markdown.md
+++ b/genesis-living-system-builder/workspaces/markdown.md
@@ -34,7 +34,7 @@ Markdown is a lightweight markup language that uses characters like `*`, `#`, an
 | **AI Agents** | Fine-tune agents using Markdown knowledge; structure prompts in agent chat |
 | **Chat & Comments** | Format team messages and task comments |
 | **Quick Add widget** | Add formatted notes and tasks from the desktop/browser widget |
-| **Genesis Context** | Upload `.md` files as app-building context |
+| **Taskade Genesis Context** | Upload `.md` files as app-building context |
 
 ---
 

--- a/genesis-living-system-builder/workspaces/mobile-optimization.md
+++ b/genesis-living-system-builder/workspaces/mobile-optimization.md
@@ -1,6 +1,6 @@
 # Mobile Living Experience
 
-**Master Taskade's mobile-first features and create apps that work beautifully across all devices. From responsive Genesis apps to native mobile workflows, ensure your users have a seamless experience whether they're on desktop, tablet, or phone.**
+**Master Taskade's mobile-first features and create apps that work beautifully across all devices. From responsive Taskade Genesis apps to native mobile workflows, ensure your users have a seamless experience whether they're on desktop, tablet, or phone.**
 
 {% hint style="success" %}
 **Mobile-First Approach:** Over 60% of users access Taskade applications on mobile devices. With our latest enhancements, mobile users now enjoy superior performance, smoother interactions, and enhanced collaboration features that make mobile work as powerful as desktop.

--- a/genesis-living-system-builder/workspaces/projects-databases.md
+++ b/genesis-living-system-builder/workspaces/projects-databases.md
@@ -6,7 +6,7 @@
 
 - [Overview](#overview)
 - [What Are Database Projects?](#what-are-database-projects)
-- [Genesis-Generated Databases](#genesis-generated-databases)
+- [Taskade Genesis-Generated Databases](#genesis-generated-databases)
 - [8 Project Views](#id-8-project-views)
 - [Manual Database Creation](#manual-database-creation)
 - [Importing Data](#importing-data)

--- a/genesis-living-system-builder/workspaces/teams.md
+++ b/genesis-living-system-builder/workspaces/teams.md
@@ -21,7 +21,7 @@
 
 Taskade is designed for teams of any size. This guide covers the different ways to organize your workspace — from small teams to large enterprises — and how AI-powered features amplify team productivity.
 
-> **Genesis hint:** Teams that use Genesis apps can give every department custom internal tools, dashboards, and client portals — all connected to the same Workspace DNA.
+> **Taskade Genesis hint:** Teams that use Genesis apps can give every department custom internal tools, dashboards, and client portals — all connected to the same Workspace DNA.
 
 ---
 

--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Get started with Taskade in minutes — build your first AI-powered app with Genesis, then add AI agents, automations, and explore the developer API.
+  Get started with Taskade in minutes — build your first AI-powered app with Taskade Genesis, then add AI agents, automations, and explore the developer API.
 ---
 
 # Quick Start Guide
@@ -55,7 +55,7 @@ Pick something you actually need:
 {% step %}
 **Open the Generator Interface**
 
-Your workspace **IS** the Genesis interface — no separate tab needed. Look for the **prominent input field at the top** of your workspace. You'll see your existing projects/folders as **app tiles** below the input field.
+Your workspace **IS** the Taskade Genesis interface — no separate tab needed. Look for the **prominent input field at the top** of your workspace. You'll see your existing projects/folders as **app tiles** below the input field.
 {% endstep %}
 
 {% step %}
@@ -75,12 +75,12 @@ When [TRIGGER EVENT], automatically [AUTOMATED ACTION].
 {% endstep %}
 
 {% step %}
-**Watch Genesis Build Your App**
+**Watch Taskade Genesis Build Your App**
 
 1. **Type or paste your prompt** in the input field at the top of your workspace
-2. **Press Enter or click Generate** — Genesis analyzes your request
+2. **Press Enter or click Generate** — Taskade Genesis analyzes your request
 3. **Your new app appears as a tile** below the generator in 30-60 seconds
-4. Genesis creates: database structure, user interface, automations, and AI functionality
+4. Taskade Genesis creates: database structure, user interface, automations, and AI functionality
 {% endstep %}
 
 {% step %}
@@ -109,7 +109,7 @@ When [TRIGGER EVENT], automatically [AUTOMATED ACTION].
 
 ## ✅ Quick Start Checklist
 
-Use this checklist to make sure you've mastered the Genesis interface:
+Use this checklist to make sure you've mastered the Taskade Genesis interface:
 
 * [ ] 🏠 **Created your workspace** and verified email
 * [ ] 🧬 **Used the generator input field** at the top to describe your first app
@@ -126,7 +126,7 @@ Use this checklist to make sure you've mastered the Genesis interface:
 
 ## Just want to manage projects? (No app building needed)
 
-You don't have to build apps with Genesis. Taskade also works as a powerful project management tool:
+You don't have to build apps with Taskade Genesis. Taskade also works as a powerful project management tool:
 
 1. **Create a project**: Click (+) in your workspace > New Project, or just start typing.
 2. **Add tasks**: Each line becomes a task. Use TAB to indent subtasks.

--- a/help-and-support/index/03_ai_agents.md
+++ b/help-and-support/index/03_ai_agents.md
@@ -300,19 +300,19 @@ Sales Opportunity → Sales Agent → Proposal Agent → Contract Agent
 
 **But the magic happens automatically—you just train them and they work!**
 
-## Real-World Agent Success Stories
+## Common agent patterns
 
-### E-commerce Company
+### Customer support
 
-**Challenge:** Customer service team overwhelmed with repetitive questions **Solution:** Deployed Support Agent trained on product catalog and policies **Result:** 60% reduction in basic support tickets, faster response times
+**Challenge:** The support team is overwhelmed with repetitive questions. **What you build:** A support agent trained on your product catalog and policies, so common questions get answered automatically.
 
-### Marketing Agency
+### Marketing content
 
-**Challenge:** Content creation bottleneck for social media and blogs **Solution:** Created Marketing Agent trained on brand guidelines and past content **Result:** 3x faster content production, consistent brand voice
+**Challenge:** Content creation for social media and blogs is a bottleneck. **What you build:** A marketing agent trained on your brand guidelines and past content, so drafts stay on-voice.
 
-### Legal Firm
+### Research & review
 
-**Challenge:** Research and document review taking excessive time **Solution:** Built Legal Agent trained on case law and firm procedures **Result:** 40% faster research, improved accuracy on routine tasks
+**Challenge:** Document review and research take excessive time. **What you build:** A research agent trained on your reference material to summarize and surface what matters.
 
 ## Your AI Agents Are Learning and Growing
 

--- a/help-and-support/index/04_automation.md
+++ b/help-and-support/index/04_automation.md
@@ -381,7 +381,7 @@ Lead enters system → Score lead quality → Assign to sales rep → Send perso
 
 **Fantastic work!** You now have intelligent workflows that coordinate your entire ecosystem automatically. Automation transforms reactive work into proactive systems that anticipate needs and handle routine tasks without human intervention.
 
-**Ready to build complete applications?** In [Chapter 5: Genesis](05_genesis.md), we'll use AI to create entire business applications from simple descriptions—no coding required!
+**Ready to build complete applications?** In [Chapter 5: Taskade Genesis](05_genesis.md), we'll use AI to create entire business applications from simple descriptions—no coding required!
 
 ***
 

--- a/help-and-support/index/05_genesis.md
+++ b/help-and-support/index/05_genesis.md
@@ -1,5 +1,5 @@
 ---
-title: 'Chapter 5: Genesis - Building Apps with AI'
+title: 'Chapter 5: Taskade Genesis - Building Apps with AI'
 parent: 'Taskade: The Living DNA Productivity Platform'
 nav_order: 5
 ---
@@ -226,23 +226,23 @@ Genesis works for virtually any business process:
 * Lead capture connects to sales pipeline automation
 * Support tickets integrate with knowledge base updates
 
-## Real-World Genesis Success Stories
+## Common build patterns
 
-### Restaurant Owner's Feedback System
+### Restaurant feedback system
 
-**Challenge:** "Customers complained but I never knew about issues until too late" **Genesis Solution:** Built feedback app in 3 minutes with auto-alerts **Result:** 40% increase in positive reviews, immediate issue resolution
+**Challenge:** Customer complaints surfaced too late to act on. **What you build:** A feedback app with automatic alerts, so low ratings reach you immediately.
 
-### Consulting Firm's Booking System
+### Consulting booking system
 
-**Challenge:** "Appointment scheduling was chaotic with constant rescheduling" **Genesis Solution:** Created booking app with calendar integration **Result:** 60% reduction in no-shows, automated confirmations
+**Challenge:** Appointment scheduling meant constant rescheduling. **What you build:** A booking app with calendar integration and automated confirmations.
 
-### E-commerce Store's Inventory Tracker
+### E-commerce inventory tracker
 
-**Challenge:** "We kept running out of popular items" **Genesis Solution:** Built inventory app with automated reorder alerts **Result:** 25% reduction in stockouts, better cash flow management
+**Challenge:** Popular items kept running out unnoticed. **What you build:** An inventory app with automated reorder alerts before stock runs low.
 
-### Marketing Agency's Lead Pipeline
+### Marketing lead pipeline
 
-**Challenge:** "Lead information got lost in email threads" **Genesis Solution:** Created lead capture with CRM integration **Result:** 3x faster lead qualification, improved conversion rates
+**Challenge:** Lead information got lost in email threads. **What you build:** A lead-capture app that routes new contacts into a structured pipeline.
 
 ## Professional App Deployment
 

--- a/help-and-support/index/06_integrations.md
+++ b/help-and-support/index/06_integrations.md
@@ -6,7 +6,7 @@ nav_order: 6
 
 # Chapter 6: Integrations - Connecting Your Tools
 
-Perfect! You've mastered building apps with Genesis. Now let's **connect your entire ecosystem**—linking Taskade to 100+ business tools for seamless workflows. This is where your workspace becomes the central nervous system of your business!
+Perfect! You've mastered building apps with Taskade Genesis. Now let's **connect your entire ecosystem**—linking Taskade to 100+ business tools for seamless workflows. This is where your workspace becomes the central nervous system of your business!
 
 ## What Problem Do Integrations Solve?
 

--- a/help-and-support/index/README.md
+++ b/help-and-support/index/README.md
@@ -18,7 +18,7 @@ Imagine your workspace isn't just a collection of projects—it's a living found
 **Taskade transforms productivity from static tools to living systems:**
 
 - **🏠 Living Workspace Foundation** - Your workspace becomes the DNA that powers everything you build
-- **🧬 Genesis AI Builder** - Describe apps in plain English, get working applications in minutes
+- **🧬 Taskade Genesis AI Builder** - Describe apps in plain English, get working applications in minutes
 - **🤖 AI Agent Team** - Deploy specialized digital assistants trained on your business
 - **⚡ Smart Automation** - Connect 100+ tools with intelligent workflow orchestration
 - **📱 Cross-Platform Magic** - Seamless experience across web, desktop, and mobile

--- a/help-center/README.md
+++ b/help-center/README.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Find answers about Taskade — Genesis app building, AI agents, automations, workspaces, billing, and troubleshooting, organized by topic.
+  Find answers about Taskade — Taskade Genesis app building, AI agents, automations, workspaces, billing, and troubleshooting, organized by topic.
 ---
 
 # Help Center

--- a/updates-and-timeline/changelog-2026/README.md
+++ b/updates-and-timeline/changelog-2026/README.md
@@ -1,6 +1,6 @@
 # Changelog (2026)
 
-Developer-focused highlights of API, MCP, SDK, automation, and Genesis platform changes shipped in 2026. For releases before 2026, see the [Changelog archive](../../changelog/README.md).
+Developer-focused highlights of API, MCP, SDK, automation, and Taskade Genesis platform changes shipped in 2026. For releases before 2026, see the [Changelog archive](../../changelog/README.md).
 
 {% hint style="info" %}
 **Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).

--- a/updates-and-timeline/changelog-2026/april-2026/april-10-2026.md
+++ b/updates-and-timeline/changelog-2026/april-2026/april-10-2026.md
@@ -4,7 +4,7 @@
 
 ### New Genesis Authentication for Apps
 
-Introducing Genesis App Authentication — a dedicated security layer for managing user access to your Genesis apps.
+Introducing Taskade Genesis App Authentication — a dedicated security layer for managing user access to your Genesis apps.
 
 <figure><img src="../../../.gitbook/assets/Clipboard-20260414-085123-796.gif" alt="" width="563"><figcaption></figcaption></figure>
 

--- a/updates-and-timeline/changelog-2026/april-2026/april-16-2026.md
+++ b/updates-and-timeline/changelog-2026/april-2026/april-16-2026.md
@@ -1,7 +1,7 @@
 # April 16, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/april-2026/april-17-2026.md
+++ b/updates-and-timeline/changelog-2026/april-2026/april-17-2026.md
@@ -1,7 +1,7 @@
 # April 17, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/april-2026/april-2-2026.md
+++ b/updates-and-timeline/changelog-2026/april-2026/april-2-2026.md
@@ -12,7 +12,7 @@ Fetch upcoming events with filters and date ranges, and check calendar availabil
 
 ### Responsive Genesis Apps
 
-Genesis apps now scale cleanly when embedded as a sidebar, viewed on mobile, or used as a full-page portal. Your apps adapt to any screen size automatically.
+Taskade Genesis apps now scale cleanly when embedded as a sidebar, viewed on mobile, or used as a full-page portal. Your apps adapt to any screen size automatically.
 
 <figure><img src="../../../.gitbook/assets/genesis-mobile-builder.gif" alt="" width="563"><figcaption></figcaption></figure>
 
@@ -28,5 +28,5 @@ New credit pack pricing with volume tiers — bigger packs give bigger bonuses. 
 
 * Public agents now auto-hide internal-only tools for safer interactions.
 * Array outputs render correctly in the automation variable picker.
-* Static assets load approximately 10% faster.
+* Static assets load faster.
 * Consolidated internal build tooling for better performance.

--- a/updates-and-timeline/changelog-2026/april-2026/april-23-2026.md
+++ b/updates-and-timeline/changelog-2026/april-2026/april-23-2026.md
@@ -1,7 +1,7 @@
 # April 23, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/april-2026/april-29-2026.md
+++ b/updates-and-timeline/changelog-2026/april-2026/april-29-2026.md
@@ -1,7 +1,7 @@
 # April 29, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/april-2026/april-30-2026.md
+++ b/updates-and-timeline/changelog-2026/april-2026/april-30-2026.md
@@ -1,7 +1,7 @@
 # April 30, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/april-2026/april-8-2026.md
+++ b/updates-and-timeline/changelog-2026/april-2026/april-8-2026.md
@@ -33,7 +33,7 @@ Broken connected accounts are now auto-detected and isolated. Smarter retry logi
 ## Improvements & Fixes:
 
 * Taskade Tips redesigned with three focused sections: Video Guides, Keyboard Shortcuts, and Quick Start.
-* More reliable sign-in for Genesis apps on custom domains.
+* More reliable sign-in for Taskade Genesis apps on custom domains.
 * EVE inspector panel restored with tighter validation.
 * GitHub Import now supports token-based sign-in for private repositories.
 * Slash commands, @-mentions, and input modals no longer hide behind the mobile chat drawer.

--- a/updates-and-timeline/changelog-2026/february-2026/february-13-2026.md
+++ b/updates-and-timeline/changelog-2026/february-2026/february-13-2026.md
@@ -20,7 +20,7 @@ Fully hosted MCP server — no self-hosting required. Deeper agent-to-external-t
 
 ### Global Language Support
 
-Full internationalization for Genesis app creation, AI chat, credit management, authentication, and error screens. Tens of thousands of new translated strings across the platform.
+Full internationalization for Taskade Genesis app creation, AI chat, credit management, authentication, and error screens. Tens of thousands of new translated strings across the platform.
 
 ***
 

--- a/updates-and-timeline/changelog-2026/february-2026/february-16-2026.md
+++ b/updates-and-timeline/changelog-2026/february-2026/february-16-2026.md
@@ -1,7 +1,7 @@
 # February 16, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/february-2026/february-18-2026.md
+++ b/updates-and-timeline/changelog-2026/february-2026/february-18-2026.md
@@ -1,7 +1,7 @@
 # February 18, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/february-2026/february-2-2026.md
+++ b/updates-and-timeline/changelog-2026/february-2026/february-2-2026.md
@@ -40,7 +40,7 @@ All major AI models are now available directly in the agent interface. A new mod
 * Community profiles are now public by default.
 * Integrated search filter and multi-select for bulk actions in List View.
 * Better retry handling for failed automation runs and improved toast alerts.
-* Custom favicon support for Genesis apps for better branding.
+* Custom favicon support for Taskade Genesis apps for better branding.
 * New "Popular" section in Actions Menu with Content & Media grouping.
 * Rename and delete agent conversations from the chat panel.
 * Mobile-optimized list view with better touch interactions.

--- a/updates-and-timeline/changelog-2026/february-2026/february-25-2026.md
+++ b/updates-and-timeline/changelog-2026/february-2026/february-25-2026.md
@@ -1,7 +1,7 @@
 # February 25, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/february-2026/february-27-2026.md
+++ b/updates-and-timeline/changelog-2026/february-2026/february-27-2026.md
@@ -1,7 +1,7 @@
 # February 27, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/january-2026/january-13-2026.md
+++ b/updates-and-timeline/changelog-2026/january-2026/january-13-2026.md
@@ -4,7 +4,7 @@
 
 ### Updated Main Genesis Page
 
-We've updated the main Genesis page with a new look and added fresh default prompts.
+We've updated the main Taskade Genesis page with a new look and added fresh default prompts.
 
 <figure><img src="../../../.gitbook/assets/CleanShot 2026-02-25 at 16.25.39@2x.png" alt="" width="563"><figcaption></figcaption></figure>
 

--- a/updates-and-timeline/changelog-2026/january-2026/january-16-2026.md
+++ b/updates-and-timeline/changelog-2026/january-2026/january-16-2026.md
@@ -1,7 +1,7 @@
 # January 16, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/january-2026/january-2-2026.md
+++ b/updates-and-timeline/changelog-2026/january-2026/january-2-2026.md
@@ -1,7 +1,7 @@
 # January 2, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/january-2026/january-29-2026.md
+++ b/updates-and-timeline/changelog-2026/january-2026/january-29-2026.md
@@ -1,7 +1,7 @@
 # January 29, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/january-2026/january-9-2026.md
+++ b/updates-and-timeline/changelog-2026/january-2026/january-9-2026.md
@@ -1,7 +1,7 @@
 # January 9, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/june-2026/README.md
+++ b/updates-and-timeline/changelog-2026/june-2026/README.md
@@ -1,6 +1,6 @@
 # June 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 

--- a/updates-and-timeline/changelog-2026/june-2026/june-1-2026.md
+++ b/updates-and-timeline/changelog-2026/june-2026/june-1-2026.md
@@ -1,7 +1,7 @@
 # June 1, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/june-2026/june-14-2026.md
+++ b/updates-and-timeline/changelog-2026/june-2026/june-14-2026.md
@@ -1,7 +1,7 @@
 # June 14, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/june-2026/june-19-2026.md
+++ b/updates-and-timeline/changelog-2026/june-2026/june-19-2026.md
@@ -1,7 +1,7 @@
 # June 19, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/june-2026/june-22-2026.md
+++ b/updates-and-timeline/changelog-2026/june-2026/june-22-2026.md
@@ -1,7 +1,7 @@
 # June 22, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/june-2026/june-23-2026.md
+++ b/updates-and-timeline/changelog-2026/june-2026/june-23-2026.md
@@ -1,7 +1,7 @@
 # June 23, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/june-2026/june-3-2026.md
+++ b/updates-and-timeline/changelog-2026/june-2026/june-3-2026.md
@@ -1,7 +1,7 @@
 # June 3, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/june-2026/june-4-2026.md
+++ b/updates-and-timeline/changelog-2026/june-2026/june-4-2026.md
@@ -1,7 +1,7 @@
 # June 4, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/june-2026/june-5-2026.md
+++ b/updates-and-timeline/changelog-2026/june-2026/june-5-2026.md
@@ -1,7 +1,7 @@
 # June 5, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/june-2026/june-9-2026.md
+++ b/updates-and-timeline/changelog-2026/june-2026/june-9-2026.md
@@ -1,7 +1,7 @@
 # June 9, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/march-2026/march-11-2026.md
+++ b/updates-and-timeline/changelog-2026/march-2026/march-11-2026.md
@@ -1,7 +1,7 @@
 # March 11, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/march-2026/march-16-2026.md
+++ b/updates-and-timeline/changelog-2026/march-2026/march-16-2026.md
@@ -1,7 +1,7 @@
 # March 16, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/march-2026/march-22-2026.md
+++ b/updates-and-timeline/changelog-2026/march-2026/march-22-2026.md
@@ -1,7 +1,7 @@
 # March 22, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/march-2026/march-28-2026.md
+++ b/updates-and-timeline/changelog-2026/march-2026/march-28-2026.md
@@ -1,7 +1,7 @@
 # March 28, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/march-2026/march-9-2026.md
+++ b/updates-and-timeline/changelog-2026/march-2026/march-9-2026.md
@@ -1,7 +1,7 @@
 # March 9, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/may-2026/README.md
+++ b/updates-and-timeline/changelog-2026/may-2026/README.md
@@ -1,5 +1,5 @@
 # May 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}

--- a/updates-and-timeline/changelog-2026/may-2026/may-1-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-1-2026.md
@@ -1,7 +1,7 @@
 # May 1, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/may-2026/may-11-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-11-2026.md
@@ -1,7 +1,7 @@
 # May 11, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/may-2026/may-12-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-12-2026.md
@@ -1,7 +1,7 @@
 # May 12, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/may-2026/may-13-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-13-2026.md
@@ -1,7 +1,7 @@
 # May 13, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/may-2026/may-14-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-14-2026.md
@@ -1,7 +1,7 @@
 # May 14, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/may-2026/may-18-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-18-2026.md
@@ -1,7 +1,7 @@
 # May 18, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/may-2026/may-20-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-20-2026.md
@@ -1,7 +1,7 @@
 # May 20, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/may-2026/may-22-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-22-2026.md
@@ -1,7 +1,7 @@
 # May 22, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/may-2026/may-26-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-26-2026.md
@@ -1,7 +1,7 @@
 # May 26, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/may-2026/may-28-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-28-2026.md
@@ -1,7 +1,7 @@
 # May 28, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/may-2026/may-29-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-29-2026.md
@@ -1,7 +1,7 @@
 # May 29, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/may-2026/may-4-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-4-2026.md
@@ -1,7 +1,7 @@
 # May 4, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/may-2026/may-5-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-5-2026.md
@@ -1,7 +1,7 @@
 # May 5, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/may-2026/may-6-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-6-2026.md
@@ -1,7 +1,7 @@
 # May 6, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/may-2026/may-7-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-7-2026.md
@@ -1,7 +1,7 @@
 # May 7, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/may-2026/may-8-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-8-2026.md
@@ -1,7 +1,7 @@
 # May 8, 2026
 
 {% hint style="info" %}
-**Developer highlights.** This section tracks API, MCP, SDK, automation, and Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
 {% endhint %}
 
 ## What's New:


### PR DESCRIPTION
## Product-name consistency + qualitative examples

A documentation polish pass for brand consistency and example quality. **Zero rendering regression** — 0 new broken internal links/anchors (verified against `main`), GitBook blocks balanced, public API surface only.

### Consistent product naming
- Refer to the app builder as **Taskade Genesis** and the in-product AI assistant as **Taskade EVE** on first mention across the docs — and consistently on the front door, the Taskade Genesis section, and the Run Your Business track.
- Slugs, file paths, and heading anchors are unchanged, so internal links and URLs keep working (0 broken anchors vs `main`).

### Example quality
- Replaced placeholder example names and illustrative figures with **qualitative, what-it-does descriptions** on the getting-started, Help Center, and reference pages (e.g., "what you get" instead of invented outcome percentages). The useful example prompts and flows are kept.
- Softened a few unverifiable infrastructure/figure claims (e.g., specific uptime numbers) to accurate, non-committal phrasing.

### Safety
Public API surface only — no internal identifiers, code paths, or feature-flag names. Leak scan clean.

cc @deanzaka @lxcid
