### PR TITLE
docs: clone-or-build start paths — link community kits & templates from the front door

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ coverY: 0
 
 <table data-view="cards"><thead><tr><th></th><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td><strong>🛠️ Build a business app — no code</strong></td><td>Describe it in plain English. Get a CRM, client portal, or ops dashboard — with logins and your own domain.</td><td><a href="genesis-living-system-builder/genesis/getting-started.md">Start building →</a></td></tr><tr><td><strong>💻 Build on the API — developers</strong></td><td>REST API v1, Action API v2, MCP, SDK, and webhooks for programmatic access.</td><td><a href="apis-living-system-development/developer-home.md">Developer platform →</a></td></tr></tbody></table>
 
+{% hint style="info" %}
+**Don't want to start from a blank prompt?** Clone a ready-made app for free — browse the [community gallery](https://www.taskade.com/community) and [Taskade's official kits](https://www.taskade.com/user/taskade), then customize it in Taskade Genesis. Or [start from scratch](https://www.taskade.com/create).
+{% endhint %}
+
 {% hint style="success" %}
 **Running a real business on a Taskade Genesis app?** Follow [Run Your Business on Genesis](genesis-living-system-builder/run-your-business/README.md) — build it, add logins, and put it on your own domain.
 {% endhint %}

--- a/genesis-living-system-builder/community-and-sharing/publish-and-clone.md
+++ b/genesis-living-system-builder/community-and-sharing/publish-and-clone.md
@@ -120,6 +120,8 @@ Published community apps track engagement automatically:
 
 ## Clone and Remix Apps
 
+Cloning is the fastest way to start — pick a working app, copy it to your workspace, and customize it instead of building from a blank prompt. Browse apps to clone in the [community gallery](https://www.taskade.com/community) and [Taskade's official kits](https://www.taskade.com/user/taskade).
+
 Any public or shared app can be cloned:
 
 | Step | Action |

--- a/genesis-living-system-builder/genesis/getting-started.md
+++ b/genesis-living-system-builder/genesis/getting-started.md
@@ -16,6 +16,10 @@ Want the deeper “why it works” model?
 
 Start with [Workspace DNA](../../genesis-living-system-builder/genesis/workspace-dna.md).
 
+{% hint style="info" %}
+**Two ways to start.** Build from a blank prompt (this guide), or **clone a ready-made app** — browse the [community gallery](https://www.taskade.com/community) and [Taskade's official kits](https://www.taskade.com/user/taskade), clone one for free, and customize it. Either way, you land in the same Taskade Genesis editor.
+{% endhint %}
+
 ## Before You Start
 
 ### What You Need

--- a/genesis-living-system-builder/run-your-business/README.md
+++ b/genesis-living-system-builder/run-your-business/README.md
@@ -18,6 +18,8 @@ Thousands of operators — consultants, clinics, realtors, agencies, constructio
 New to Taskade Genesis? Start with [Your first app in 5 minutes](../genesis/getting-started.md), then come back here to turn it into a business you run.
 {% endhint %}
 
+**Build your own, or start from a kit.** Describe your business and [build from scratch](https://www.taskade.com/create), or clone a ready-made app for free from the [community gallery](https://www.taskade.com/community) or [Taskade's official kits](https://www.taskade.com/user/taskade) and make it yours. Both paths lead to the same steps below.
+
 | You want to… | Start here |
 | --- | --- |
 | See the whole journey end to end | [From idea to live business — the 5 steps](from-idea-to-live-business.md) |


### PR DESCRIPTION
## Clone or build — connect the no-code start paths

Surfaces the "clone a ready-made app vs build your own" choice for the no-code audience, and links the places to find clonable apps. **Zero rendering regression** (0 broken internal links/anchors vs `main`; GitBook blocks balanced).

- **Front door (README)**: a note under the build/develop chooser — clone for free from the [community gallery](https://www.taskade.com/community) and [official kits](https://www.taskade.com/user/taskade), or start from a blank prompt at [taskade.com/create](https://www.taskade.com/create).
- **Getting started**: a "two ways to start" callout (clone vs build) — both land in the same Taskade Genesis editor.
- **Run Your Business hub**: a build-your-own-or-start-from-a-kit line before the journey table.
- **Publish & clone**: links to where to browse apps to clone (community gallery + official kits).

All links point to public taskade.com destinations.

cc @deanzaka @lxcid
