### PR TITLE
docs: add Mermaid diagrams to key concept & developer pages

### DIFF
--- a/apis-living-system-development/api-v2-reference.md
+++ b/apis-living-system-development/api-v2-reference.md
@@ -71,6 +71,23 @@ See the [Authentication guide](developers/authentication.md) for personal tokens
 
 Every v2 call is a `POST` to an operation name, with a JSON body and a JSON response. Successful responses are wrapped in `{ "ok": true, ... }`.
 
+Here is a single Action API v2 call, from authentication to JSON response.
+
+```mermaid
+sequenceDiagram
+  participant C as Client
+  participant T as Taskade Action API v2
+  Note over C: Authenticate with PAT or OAuth 2.0 token
+  C->>T: POST /operation with Bearer token and JSON body
+  T->>T: Process operation
+  alt Success
+    T-->>C: JSON response, ok true
+  else Error
+    T-->>C: JSON error, ok false, message and code
+  end
+```
+
+
 ```bash
 curl -X POST https://www.taskade.com/api/v2/OPERATION \
   -H "Authorization: Bearer YOUR_TOKEN" \

--- a/apis-living-system-development/workspace-mcp.md
+++ b/apis-living-system-development/workspace-mcp.md
@@ -14,6 +14,20 @@ Workspace MCP connects [Claude Desktop](https://claude.ai), [Cursor](https://cur
 
 The [Model Context Protocol](https://modelcontextprotocol.io/) lets AI assistants interact with external tools and data sources. The `@taskade/mcp-server` package exposes Taskade's API as MCP tools your AI client can call.
 
+The MCP client talks to a locally run server, which wraps REST API v1 to reach your workspace content.
+
+```mermaid
+graph LR
+  A["MCP client<br/>(Claude Desktop, Cursor, VS Code)"] -->|MCP tools| B["@taskade/mcp-server<br/>(runs locally)"]
+  B -->|PAT via TASKADE_API_KEY| C["REST API v1"]
+  C --> D["Workspaces"]
+  C --> E["Projects"]
+  C --> F["Tasks"]
+  C --> G["Agents"]
+  C --> H["Media"]
+```
+
+
 ## Install & run
 
 The server is published as **`@taskade/mcp-server`** on npm. The simplest setup runs it on demand with `npx` — no global install needed:

--- a/genesis-living-system-builder/ai-features/multi-agents.md
+++ b/genesis-living-system-builder/ai-features/multi-agents.md
@@ -21,6 +21,23 @@
 
 Multi-Agents lets you **assign multiple AI agents to work together** on projects, tasks, and conversations. Instead of relying on a single generalist AI, you create teams of specialized agents that collaborate — each bringing domain expertise, unique knowledge, and specific tools.
 
+Specialized agents, Taskade EVE, and people coordinate around one shared project.
+
+```mermaid
+graph TD
+  HUMAN["Human team members<br/>direction and decisions"] --> WS["Shared project / workspace"]
+  WS --> EVE["Taskade EVE<br/>orchestrates and invokes agents"]
+  EVE --> RES["Research Agent"]
+  EVE --> ANL["Analyst Agent"]
+  EVE --> WRT["Writer Agent"]
+  EVE --> COORD["Coordinator Agent"]
+  RES --> WS
+  ANL --> WS
+  WRT --> WS
+  COORD --> WS
+```
+
+
 > **Workspace DNA impact:** Multi-agent teams amplify the Intelligence pillar. Each agent contributes +10 points to your [Intelligence Score](../genesis/how-genesis-works.md#workspace-intelligence-score), and teams create compounding intelligence through specialization.
 >
 > **Plan note:** Multi-Agent Teams are available on Business+ plans.

--- a/genesis-living-system-builder/automation/README.md
+++ b/genesis-living-system-builder/automation/README.md
@@ -28,6 +28,22 @@ Automations let you build trigger-and-action workflows that run on their own —
 
 Living Motion is Taskade’s automation layer. It’s how your workspace can **react**, **decide**, and **execute** when something happens.
 
+Every automation follows the same shape: a trigger starts it, an optional condition routes it, and actions do the work.
+
+```mermaid
+flowchart TD
+  A["Trigger<br/>schedule, form, webhook, or project event"] --> B{"Condition / Filter"}
+  B -->|matches| C["Actions"]
+  B -->|no match| E["Stop"]
+  C --> D["AI step<br/>Taskade EVE classifies or drafts"]
+  C --> F["Integration<br/>notify or sync a connected tool"]
+  C --> G["Update tasks in Taskade Genesis"]
+  D --> H["Result"]
+  F --> H
+  G --> H
+```
+
+
 Canonical foundation: [Workspace DNA](../../genesis-living-system-builder/genesis/workspace-dna.md).
 
 ### What you use it for

--- a/genesis-living-system-builder/genesis/how-genesis-works.md
+++ b/genesis-living-system-builder/genesis/how-genesis-works.md
@@ -26,6 +26,20 @@
 
 This guide explains the core architecture behind **Taskade Genesis** — the AI platform that transforms natural language into complete, living business applications. You'll learn:
 
+At a high level, here is how a plain-English prompt becomes a working app you can preview and refine.
+
+```mermaid
+flowchart TD
+  A["Plain-English prompt"] --> B["Taskade Genesis"]
+  B --> C["App UI (React)"]
+  B --> D["Workspace backend<br/>Projects & Databases"]
+  B --> E["AI Agents"]
+  B --> F["Automations"]
+  C --> G["Preview and refine"]
+  G -->|describe changes| B
+```
+
+
 - **The Tree of Life:** How Memory (Projects), Intelligence (Agents), and Action (Automations) form a continuous cycle that powers living software.
 - **Workspace DNA:** What your workspace's genetic code is and why every app you build is unique.
 - **EVE:** How Taskade's unified AI system connects everything together.

--- a/genesis-living-system-builder/genesis/workspace-dna.md
+++ b/genesis-living-system-builder/genesis/workspace-dna.md
@@ -10,6 +10,25 @@ Every Taskade workspace runs on three pillars that work together as a continuous
 
 ## The Three Pillars
 
+The three pillars form one workspace, each feeding the next in a continuous cycle.
+
+```mermaid
+graph TD
+  WS["Unified Taskade Workspace"]
+  MEM["Memory<br/>Projects & Databases"]
+  INT["Intelligence<br/>AI Agents"]
+  EXE["Execution<br/>Automations"]
+  EVE["Taskade EVE<br/>reads the whole Workspace DNA"]
+  WS --> MEM
+  WS --> INT
+  WS --> EXE
+  MEM -->|agents read data| INT
+  INT -->|decisions and drafts| EXE
+  EXE -->|updates results| MEM
+  EVE --> WS
+```
+
+
 ### 1. Memory — Projects & Databases
 
 Projects store structured knowledge: tasks, notes, custom fields, documents, and media. This is what agents read and automations update.

--- a/genesis-living-system-builder/run-your-business/from-idea-to-live-business.md
+++ b/genesis-living-system-builder/run-your-business/from-idea-to-live-business.md
@@ -8,6 +8,17 @@ description: >-
 
 You have a business problem and an idea for an app that fixes it. This guide is the spine: five steps that take you from a plain-English idea to a real, branded app your customers can sign in to and use. Each step links to a full guide when you want the detail.
 
+The five steps form one path from idea to a live, branded app.
+
+```mermaid
+graph LR
+  A["Step 1<br/>Describe your app<br/>to Taskade Genesis"] --> B["Step 2<br/>Shape data into a<br/>system of record"]
+  B --> C["Step 3<br/>Add login and roles"]
+  C --> D["Step 4<br/>Put it on your<br/>own domain"]
+  D --> E["Step 5<br/>Right-size your plan<br/>and go live"]
+```
+
+
 ***
 
 ## Step 1 — Describe your app to Genesis


### PR DESCRIPTION
## Visual diagrams for key pages

Adds one accurate Mermaid diagram to seven pages that previously had none — to make core concepts and flows scannable. **Zero rendering regression** (0 broken internal links/anchors vs `main`; all Mermaid blocks valid; GitBook blocks balanced).

Each diagram is grounded only in what its page already describes (no new claims):
- **Workspace DNA** — the Memory → Intelligence → Execution cycle, with Taskade EVE reading the whole graph.
- **How Taskade Genesis works** — prompt → app UI + workspace backend + agents + automations → preview/iterate loop.
- **Automations** — trigger → condition/filter → actions → result.
- **From idea to live business** — the 5-step journey, left to right.
- **Multi-agents** — specialized agents + Taskade EVE coordinating around a shared project.
- **Action API v2** — request lifecycle (PAT/OAuth → POST operation → JSON response).
- **Workspace MCP** — MCP client → `@taskade/mcp-server` (local) → REST API v1 → workspace content.

GitBook renders fenced ` ```mermaid ` blocks natively.

cc @deanzaka @lxcid
