### PR TITLE
docs: SEO/AEO — meta descriptions for all 250 pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ---
-description: Describe your business in plain English and get a real, running app — CRM, client portal, or ops dashboard — with logins and your own domain. No code, plus a full developer API.
+description: >-
+  Describe your business in plain English and get a real, running app — CRM, client portal, or ops dashboard. No code, plus a full developer API.
 cover: .gitbook/assets/ss-api3.png
 coverY: 0
 ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Security guidelines for Taskade docs contributors: never commit .env files, API keys, or tokens, use placeholder values, and clean git history if secrets leak.
+---
+
 # Security Guidelines for Contributors
 
 **⚠️ CRITICAL: This is a PUBLIC repository that powers [docs.taskade.com](https://docs.taskade.com). Never commit sensitive information!**

--- a/account-management/README.md
+++ b/account-management/README.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Manage your Taskade account: update profile, invite members and set roles, handle billing and plans, AI credits, 2FA, SSO/SAML, and data export.
+---
+
 # Account Management
 
 Manage your Taskade account, team, billing, and security settings.

--- a/account-management/credits-and-billing.md
+++ b/account-management/credits-and-billing.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Understand how Taskade AI credits work, what drives app costs, credit pack pricing, and Auto Top-Up that refills your balance before agents run dry.
+---
+
 # Credits & Billing
 
 Understand how AI credits work in Taskade, how credit packs are priced, and how Auto Top-Up keeps your workflows running.

--- a/apis-living-system-development/comprehensive-api-guide/agents/README.md
+++ b/apis-living-system-development/comprehensive-api-guide/agents/README.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Agents — Taskade REST API v1 reference: GET /public-agents/{publicAgentId}. Parameters, authentication, and response schema.
+---
+
 # Agents
 
 The **Intelligence Layer** is the brain of your application. It's where reasoning, logic, and autonomous action take place. This layer is powered by **Taskade's AI Agents**.

--- a/apis-living-system-development/comprehensive-api-guide/agents/add-media-to-agent-knowledge.md
+++ b/apis-living-system-development/comprehensive-api-guide/agents/add-media-to-agent-knowledge.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Add Media to Agent Knowledge — Taskade REST API v1 reference: POST /agents/{agentId}/knowledge/media. Parameters, authentication, and response schema.
+---
+
 # Add Media to Agent Knowledge
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/agents/{agentId}/knowledge/media" method="post" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/agents/add-project-to-agent-knowledge.md
+++ b/apis-living-system-development/comprehensive-api-guide/agents/add-project-to-agent-knowledge.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Add Project to Agent Knowledge — Taskade REST API v1 reference: POST /agents/{agentId}/knowledge/project. Parameters, authentication, and response schema.
+---
+
 # Add Project to Agent Knowledge
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/agents/{agentId}/knowledge/project" method="post" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/agents/delete-agent.md
+++ b/apis-living-system-development/comprehensive-api-guide/agents/delete-agent.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Delete Agent — Taskade REST API v1 reference: DELETE /agents/{agentId}. Parameters, authentication, and response schema.
+---
+
 # Delete Agent
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/agents/{agentId}" method="delete" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/agents/get-agent-convo.md
+++ b/apis-living-system-development/comprehensive-api-guide/agents/get-agent-convo.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Get Agent Conversation — Taskade REST API v1 reference: GET /agents/{agentId}/convos/{convoId}. Parameters, authentication, and response schema.
+---
+
 # Get Agent Conversation
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/agents/{agentId}/convos/{convoId}" method="get" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/agents/get-agent-convos.md
+++ b/apis-living-system-development/comprehensive-api-guide/agents/get-agent-convos.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Get Agent Conversations — Taskade REST API v1 reference: GET /agents/{agentId}/convos/. Parameters, authentication, and response schema.
+---
+
 # Get Agent Conversations
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/agents/{agentId}/convos/" method="get" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/agents/get-agent.md
+++ b/apis-living-system-development/comprehensive-api-guide/agents/get-agent.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Get Agent — Taskade REST API v1 reference: GET /agents/{agentId}. Parameters, authentication, and response schema.
+---
+
 # Get Agent
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/agents/{agentId}" method="get" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/agents/get-public-agent.md
+++ b/apis-living-system-development/comprehensive-api-guide/agents/get-public-agent.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Get Public Agent — Taskade REST API v1 reference: GET /agents/{agentId}/public-agent. Parameters, authentication, and response schema.
+---
+
 # Get Public Agent
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/agents/{agentId}/public-agent" method="get" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/agents/lookup-public-agent.md
+++ b/apis-living-system-development/comprehensive-api-guide/agents/lookup-public-agent.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Look Up Public Agent — Taskade REST API v1 reference: GET /public-agents/{publicAgentId}. Parameters, authentication, and response schema.
+---
+
 # Look Up Public Agent
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/public-agents/{publicAgentId}" method="get" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/agents/remove-media-from-agent-knowledge.md
+++ b/apis-living-system-development/comprehensive-api-guide/agents/remove-media-from-agent-knowledge.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Remove Media from Agent Knowledge — Taskade REST API v1 reference: DELETE /agents/{agentId}/knowledge/media/{mediaId}. Parameters, authentication, and…
+---
+
 # Remove Media from Agent Knowledge
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/agents/{agentId}/knowledge/media/{mediaId}" method="delete" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/agents/remove-project-from-agent-knowledge.md
+++ b/apis-living-system-development/comprehensive-api-guide/agents/remove-project-from-agent-knowledge.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Remove Project from Agent Knowledge — Taskade REST API v1 reference: DELETE /agents/{agentId}/knowledge/project/{projectId}. Parameters, authentication,…
+---
+
 # Remove Project from Agent Knowledge
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/agents/{agentId}/knowledge/project/{projectId}" method="delete" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/agents/update-agent-public-access.md
+++ b/apis-living-system-development/comprehensive-api-guide/agents/update-agent-public-access.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Update Agent Public Access — Taskade REST API v1 reference: PUT /agents/{agentId}/publicAccess. Parameters, authentication, and response schema.
+---
+
 # Update Agent Public Access
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/agents/{agentId}/publicAccess" method="put" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/agents/update-agent.md
+++ b/apis-living-system-development/comprehensive-api-guide/agents/update-agent.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Update Agent — Taskade REST API v1 reference: PATCH /agents/{agentId}. Parameters, authentication, and response schema.
+---
+
 # Update Agent
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/agents/{agentId}" method="patch" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/agents/update-public-agent.md
+++ b/apis-living-system-development/comprehensive-api-guide/agents/update-public-agent.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Update Public Agent — Taskade REST API v1 reference: PATCH /agents/{agentId}/public-agent. Parameters, authentication, and response schema.
+---
+
 # Update Public Agent
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/agents/{agentId}/public-agent" method="patch" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/folders/README.md
+++ b/apis-living-system-development/comprehensive-api-guide/folders/README.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Folders — Taskade REST API v1 reference: GET /folders/{folderId}/projects. Parameters, authentication, and response schema.
+---
+
 # Folders
 
 A **Subspace** is the top-level container for every AI-powered application you build on Taskade. It's more than just a folder; it's the complete, self-contained ecosystem for your app, holding its unique Knowledge, Intelligence, and Action layers.

--- a/apis-living-system-development/comprehensive-api-guide/folders/create-agent-in-folder.md
+++ b/apis-living-system-development/comprehensive-api-guide/folders/create-agent-in-folder.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Create Agent in Folder — Taskade REST API v1 reference: POST /folders/{folderId}/agents. Parameters, authentication, and response schema.
+---
+
 # Create Agent in Folder
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/folders/{folderId}/agents" method="post" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/folders/generate-agent-in-folder.md
+++ b/apis-living-system-development/comprehensive-api-guide/folders/generate-agent-in-folder.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Generate Agent in Folder — Taskade REST API v1 reference: POST /folders/{folderId}/agent-generate. Parameters, authentication, and response schema.
+---
+
 # Generate Agent in Folder
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/folders/{folderId}/agent-generate" method="post" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/folders/get-folder-agents.md
+++ b/apis-living-system-development/comprehensive-api-guide/folders/get-folder-agents.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Get Folder Agents — Taskade REST API v1 reference: GET /folders/{folderId}/agents. Parameters, authentication, and response schema.
+---
+
 # Get Folder Agents
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/folders/{folderId}/agents" method="get" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/folders/get-folder-medias.md
+++ b/apis-living-system-development/comprehensive-api-guide/folders/get-folder-medias.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Get Folder Medias — Taskade REST API v1 reference: GET /folders/{folderId}/medias. Parameters, authentication, and response schema.
+---
+
 # Get Folder Medias
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/folders/{folderId}/medias" method="get" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/folders/get-folder-project-templates.md
+++ b/apis-living-system-development/comprehensive-api-guide/folders/get-folder-project-templates.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Get Folder Project Templates — Taskade REST API v1 reference: GET /folders/{folderId}/project-templates. Parameters, authentication, and response schema.
+---
+
 # Get Folder Project Templates
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/folders/{folderId}/project-templates" method="get" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/folders/get-folder-projects.md
+++ b/apis-living-system-development/comprehensive-api-guide/folders/get-folder-projects.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Get Folder Projects — Taskade REST API v1 reference: GET /folders/{folderId}/projects. Parameters, authentication, and response schema.
+---
+
 # Get Folder Projects
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/folders/{folderId}/projects" method="get" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/me/README.md
+++ b/apis-living-system-development/comprehensive-api-guide/me/README.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Me — Taskade REST API v1 reference: GET /me/projects. Parameters, authentication, and response schema.
+---
+
 # Me
 
 ## Summary of Endpoints

--- a/apis-living-system-development/comprehensive-api-guide/media/README.md
+++ b/apis-living-system-development/comprehensive-api-guide/media/README.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Media — Taskade REST API v1 reference: GET /medias/{mediaId}. Parameters, authentication, and response schema.
+---
+
 # Media
 
 ## Summary of Endpoints

--- a/apis-living-system-development/comprehensive-api-guide/media/delete-media.md
+++ b/apis-living-system-development/comprehensive-api-guide/media/delete-media.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Delete Media — Taskade REST API v1 reference: DELETE /medias/{mediaId}. Parameters, authentication, and response schema.
+---
+
 # Delete Media
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/medias/{mediaId}" method="delete" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/media/download-media-from-space.md
+++ b/apis-living-system-development/comprehensive-api-guide/media/download-media-from-space.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Download Media from Space — Taskade REST API v1 reference: GET /medias/spaces/{spaceId}/download. Parameters, authentication, and response schema.
+---
+
 # Download Media from Space
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/medias/spaces/{spaceId}/download" method="get" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/media/download-media.md
+++ b/apis-living-system-development/comprehensive-api-guide/media/download-media.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Download Media — Taskade REST API v1 reference: GET /medias/{mediaId}/download. Parameters, authentication, and response schema.
+---
+
 # Download Media
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/medias/{mediaId}/download" method="get" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/media/get-media.md
+++ b/apis-living-system-development/comprehensive-api-guide/media/get-media.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Get Media — Taskade REST API v1 reference: GET /medias/{mediaId}. Parameters, authentication, and response schema.
+---
+
 # Get Media
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/medias/{mediaId}" method="get" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/media/upload-media-to-space.md
+++ b/apis-living-system-development/comprehensive-api-guide/media/upload-media-to-space.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Upload Media to Space — Taskade REST API v1 reference: POST /medias/spaces/{spaceId}/upload. Parameters, authentication, and response schema.
+---
+
 # Upload Media to Space
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/medias/spaces/{spaceId}/upload" method="post" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/projects/README.md
+++ b/apis-living-system-development/comprehensive-api-guide/projects/README.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Projects — Taskade REST API v1 reference: GET /projects/{projectId}. Parameters, authentication, and response schema.
+---
+
 # Projects
 
 The **Knowledge Layer** is the foundation of every intelligent app you build in Taskade. This is the structured memory that your AI Agents use to understand context, make decisions, and provide insightful responses. This layer is powered by **Taskade Projects**.

--- a/apis-living-system-development/comprehensive-api-guide/projects/complete-project.md
+++ b/apis-living-system-development/comprehensive-api-guide/projects/complete-project.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Complete Project — Taskade REST API v1 reference: POST /projects/{projectId}/complete. Parameters, authentication, and response schema.
+---
+
 # Complete Project
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/{projectId}/complete" method="post" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/projects/copy-project.md
+++ b/apis-living-system-development/comprehensive-api-guide/projects/copy-project.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Copy Project — Taskade REST API v1 reference: POST /projects/{projectId}/copy. Parameters, authentication, and response schema.
+---
+
 # Copy Project
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/{projectId}/copy" method="post" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/projects/create-from-template.md
+++ b/apis-living-system-development/comprehensive-api-guide/projects/create-from-template.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Create From Template — Taskade REST API v1 reference: POST /projects/from-template. Parameters, authentication, and response schema.
+---
+
 # Create From Template
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/from-template" method="post" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/projects/create-project.md
+++ b/apis-living-system-development/comprehensive-api-guide/projects/create-project.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Create Project — Taskade REST API v1 reference: POST /projects. Parameters, authentication, and response schema.
+---
+
 # Create Project
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects" method="post" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/projects/get-project-block.md
+++ b/apis-living-system-development/comprehensive-api-guide/projects/get-project-block.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Get Project Block — Taskade REST API v1 reference: GET /projects/{projectId}/blocks. Parameters, authentication, and response schema.
+---
+
 # Get Project Block
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/{projectId}/blocks" method="get" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/projects/get-project-fields.md
+++ b/apis-living-system-development/comprehensive-api-guide/projects/get-project-fields.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Get Project Fields — Taskade REST API v1 reference: GET /projects/{projectId}/fields. Parameters, authentication, and response schema.
+---
+
 # Get Project Fields
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/{projectId}/fields" method="get" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/projects/get-project-members.md
+++ b/apis-living-system-development/comprehensive-api-guide/projects/get-project-members.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Get Project Members — Taskade REST API v1 reference: GET /projects/{projectId}/members. Parameters, authentication, and response schema.
+---
+
 # Get Project Members
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/{projectId}/members" method="get" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/projects/get-project-tasks.md
+++ b/apis-living-system-development/comprehensive-api-guide/projects/get-project-tasks.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Get Project Tasks — Taskade REST API v1 reference: GET /projects/{projectId}/tasks. Parameters, authentication, and response schema.
+---
+
 # Get Project Tasks
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/{projectId}/tasks" method="get" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/projects/get-project.md
+++ b/apis-living-system-development/comprehensive-api-guide/projects/get-project.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Get Project — Taskade REST API v1 reference: GET /projects/{projectId}. Parameters, authentication, and response schema.
+---
+
 # Get Project
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/{projectId}" method="get" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/projects/get-share-link.md
+++ b/apis-living-system-development/comprehensive-api-guide/projects/get-share-link.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Get Share Link — Taskade REST API v1 reference: GET /projects/{projectId}/shareLink. Parameters, authentication, and response schema.
+---
+
 # Get Share Link
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/{projectId}/shareLink" method="get" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/projects/restore-project.md
+++ b/apis-living-system-development/comprehensive-api-guide/projects/restore-project.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Restore Project — Taskade REST API v1 reference: POST /projects/{projectId}/restore. Parameters, authentication, and response schema.
+---
+
 # Restore Project
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/{projectId}/restore" method="post" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/projects/update-share-link.md
+++ b/apis-living-system-development/comprehensive-api-guide/projects/update-share-link.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Update Share Link — Taskade REST API v1 reference: PUT /projects/{projectId}/shareLink. Parameters, authentication, and response schema.
+---
+
 # Update Share Link
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/{projectId}/shareLink" method="put" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/tasks/README.md
+++ b/apis-living-system-development/comprehensive-api-guide/tasks/README.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Tasks — Taskade REST API v1 reference: GET /projects/{projectId}/tasks/{taskId}. Parameters, authentication, and response schema.
+---
+
 # Tasks
 
 ## Summary of Endpoints

--- a/apis-living-system-development/comprehensive-api-guide/tasks/complete-task.md
+++ b/apis-living-system-development/comprehensive-api-guide/tasks/complete-task.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Complete Task — Taskade REST API v1 reference: POST /projects/{projectId}/tasks/{taskId}/complete. Parameters, authentication, and response schema.
+---
+
 # Complete Task
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/{projectId}/tasks/{taskId}/complete" method="post" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/tasks/create-task.md
+++ b/apis-living-system-development/comprehensive-api-guide/tasks/create-task.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Create Task — Taskade REST API v1 reference: POST /projects/{projectId}/tasks/. Parameters, authentication, and response schema.
+---
+
 # Create Task
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/{projectId}/tasks/" method="post" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/tasks/delete-task-assignees.md
+++ b/apis-living-system-development/comprehensive-api-guide/tasks/delete-task-assignees.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Delete Task Assignees — Taskade REST API v1 reference: DELETE /projects/{projectId}/tasks/{taskId}/assignees/{assigneeHandle}. Parameters,…
+---
+
 # Delete Task Assignees
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/{projectId}/tasks/{taskId}/assignees/{assigneeHandle}" method="delete" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/tasks/delete-task-date.md
+++ b/apis-living-system-development/comprehensive-api-guide/tasks/delete-task-date.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Delete Task Date — Taskade REST API v1 reference: DELETE /projects/{projectId}/tasks/{taskId}/date. Parameters, authentication, and response schema.
+---
+
 # Delete Task Date
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/{projectId}/tasks/{taskId}/date" method="delete" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/tasks/delete-task-field.md
+++ b/apis-living-system-development/comprehensive-api-guide/tasks/delete-task-field.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Delete Task Field — Taskade REST API v1 reference: DELETE /projects/{projectId}/tasks/{taskId}/fields/{fieldId}. Parameters, authentication, and response…
+---
+
 # Delete Task Field
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/{projectId}/tasks/{taskId}/fields/{fieldId}" method="delete" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/tasks/delete-task-note.md
+++ b/apis-living-system-development/comprehensive-api-guide/tasks/delete-task-note.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Delete Task Note — Taskade REST API v1 reference: DELETE /projects/{projectId}/tasks/{taskId}/note. Parameters, authentication, and response schema.
+---
+
 # Delete Task Note
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/{projectId}/tasks/{taskId}/note" method="delete" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/tasks/delete-task.md
+++ b/apis-living-system-development/comprehensive-api-guide/tasks/delete-task.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Delete Task — Taskade REST API v1 reference: DELETE /projects/{projectId}/tasks/{taskId}. Parameters, authentication, and response schema.
+---
+
 # Delete Task
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/{projectId}/tasks/{taskId}" method="delete" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/tasks/get-task-assignees.md
+++ b/apis-living-system-development/comprehensive-api-guide/tasks/get-task-assignees.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Task Assignees — Taskade REST API v1 reference: GET /projects/{projectId}/tasks/{taskId}/assignees. Parameters, authentication, and response schema.
+---
+
 # Task Assignees
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/{projectId}/tasks/{taskId}/assignees" method="get" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/tasks/get-task-date.md
+++ b/apis-living-system-development/comprehensive-api-guide/tasks/get-task-date.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Get Task Date — Taskade REST API v1 reference: GET /projects/{projectId}/tasks/{taskId}/date. Parameters, authentication, and response schema.
+---
+
 # Get Task Date
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/{projectId}/tasks/{taskId}/date" method="get" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/tasks/get-task-field.md
+++ b/apis-living-system-development/comprehensive-api-guide/tasks/get-task-field.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Get Task Field — Taskade REST API v1 reference: GET /projects/{projectId}/tasks/{taskId}/fields/{fieldId}. Parameters, authentication, and response schema.
+---
+
 # Get Task Field
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/{projectId}/tasks/{taskId}/fields/{fieldId}" method="get" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/tasks/get-task-note.md
+++ b/apis-living-system-development/comprehensive-api-guide/tasks/get-task-note.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Get Task Note — Taskade REST API v1 reference: GET /projects/{projectId}/tasks/{taskId}/note. Parameters, authentication, and response schema.
+---
+
 # Get Task Note
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/{projectId}/tasks/{taskId}/note" method="get" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/tasks/get-task.md
+++ b/apis-living-system-development/comprehensive-api-guide/tasks/get-task.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Get Task — Taskade REST API v1 reference: GET /projects/{projectId}/tasks/{taskId}. Parameters, authentication, and response schema.
+---
+
 # Get Task
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/{projectId}/tasks/{taskId}" method="get" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/tasks/list-task-fields.md
+++ b/apis-living-system-development/comprehensive-api-guide/tasks/list-task-fields.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  List Task Fields — Taskade REST API v1 reference: GET /projects/{projectId}/tasks/{taskId}/fields. Parameters, authentication, and response schema.
+---
+
 # List Task Fields
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/{projectId}/tasks/{taskId}/fields" method="get" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/tasks/move-task.md
+++ b/apis-living-system-development/comprehensive-api-guide/tasks/move-task.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Move Task — Taskade REST API v1 reference: PUT /projects/{projectId}/tasks/{taskId}/move. Parameters, authentication, and response schema.
+---
+
 # Move Task
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/{projectId}/tasks/{taskId}/move" method="put" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/tasks/uncomplete-task.md
+++ b/apis-living-system-development/comprehensive-api-guide/tasks/uncomplete-task.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Uncomplete Task — Taskade REST API v1 reference: POST /projects/{projectId}/tasks/{taskId}/uncomplete. Parameters, authentication, and response schema.
+---
+
 # Uncomplete Task
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/{projectId}/tasks/{taskId}/uncomplete" method="post" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/tasks/update-task-assignees.md
+++ b/apis-living-system-development/comprehensive-api-guide/tasks/update-task-assignees.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Update Task Assignees — Taskade REST API v1 reference: PUT /projects/{projectId}/tasks/{taskId}/assignees. Parameters, authentication, and response schema.
+---
+
 # Update Task Assignees
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/{projectId}/tasks/{taskId}/assignees" method="put" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/tasks/update-task-date.md
+++ b/apis-living-system-development/comprehensive-api-guide/tasks/update-task-date.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Update Task Date — Taskade REST API v1 reference: PUT /projects/{projectId}/tasks/{taskId}/date. Parameters, authentication, and response schema.
+---
+
 # Update Task Date
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/{projectId}/tasks/{taskId}/date" method="put" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/tasks/update-task-field.md
+++ b/apis-living-system-development/comprehensive-api-guide/tasks/update-task-field.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Update Task Field — Taskade REST API v1 reference: PUT /projects/{projectId}/tasks/{taskId}/fields/{fieldId}. Parameters, authentication, and response…
+---
+
 # Update Task Field
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/{projectId}/tasks/{taskId}/fields/{fieldId}" method="put" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/tasks/update-task-note.md
+++ b/apis-living-system-development/comprehensive-api-guide/tasks/update-task-note.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Update Task Note — Taskade REST API v1 reference: PUT /projects/{projectId}/tasks/{taskId}/note. Parameters, authentication, and response schema.
+---
+
 # Update Task Note
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/{projectId}/tasks/{taskId}/note" method="put" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/tasks/update-task.md
+++ b/apis-living-system-development/comprehensive-api-guide/tasks/update-task.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Update Task — Taskade REST API v1 reference: PUT /projects/{projectId}/tasks/{taskId}. Parameters, authentication, and response schema.
+---
+
 # Update Task
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/projects/{projectId}/tasks/{taskId}" method="put" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/workspaces/README.md
+++ b/apis-living-system-development/comprehensive-api-guide/workspaces/README.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Workspaces — Taskade REST API v1 reference: GET /workspaces. Parameters, authentication, and response schema.
+---
+
 # Workspaces
 
 ## Summary of Endpoints

--- a/apis-living-system-development/comprehensive-api-guide/workspaces/get-folders.md
+++ b/apis-living-system-development/comprehensive-api-guide/workspaces/get-folders.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Get Folders — Taskade REST API v1 reference: GET /workspaces/{workspaceId}/folders. Parameters, authentication, and response schema.
+---
+
 # Get Folders
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/workspaces/{workspaceId}/folders" method="get" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/workspaces/get-projects.md
+++ b/apis-living-system-development/comprehensive-api-guide/workspaces/get-projects.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Create a Project in a Workspace — Taskade REST API v1 reference: POST /workspaces/{workspaceId}/projects. Parameters, authentication, and response schema.
+---
+
 # Create a Project in a Workspace
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/workspaces/{workspaceId}/projects" method="post" expanded="true" %}

--- a/apis-living-system-development/comprehensive-api-guide/workspaces/get-workspaces.md
+++ b/apis-living-system-development/comprehensive-api-guide/workspaces/get-workspaces.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Get Workspaces — Taskade REST API v1 reference: GET /workspaces. Parameters, authentication, and response schema.
+---
+
 # Get Workspaces
 
 {% openapi src="../../../.gitbook/assets/api-0.1.0.json" path="/workspaces" method="get" expanded="true" %}

--- a/apis-living-system-development/developers/README.md
+++ b/apis-living-system-development/developers/README.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Build on Taskade with the REST API, OAuth 2.0 and personal tokens, MCP server, webhooks, and Genesis app generation, agents, and automation.
+---
+
 # Developer Overview
 
 **Build on Taskade's platform for applications, agents, and automation.**

--- a/apis-living-system-development/developers/api.md
+++ b/apis-living-system-development/developers/api.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Build integrations on the Taskade REST API: manage workspaces, projects, tasks, AI agents, and media via authenticated endpoints with Node, Python, and cURL.
+---
+
 # Living Intelligence API Overview
 
 **Connect. Build. Automate.** The Taskade API enables you to programmatically access and manage your Taskade workspace, projects, tasks, agents, and more.

--- a/apis-living-system-development/developers/personal-tokens.md
+++ b/apis-living-system-development/developers/personal-tokens.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Generate a Taskade Personal Access Token and authenticate API requests with the Authorization Bearer header. Simpler than full OAuth 2.0.
+---
+
 # Personal Tokens
 
 Authentication is a crucial aspect of ensuring the security and integrity of your interactions with our API. We provide two distinct methods for authentication.

--- a/changelog/2017-2019/README.md
+++ b/changelog/2017-2019/README.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade 2017-2019 changelog — historical release notes, feature launches, and platform updates.
+---
+
 # 2017-2019 Foundation Years: Platform Genesis
 
 **From Humble Beginnings to Growth** - The collaborative productivity platform takes shape, establishing the foundational DNA that would eventually evolve into Taskade Genesis.

--- a/changelog/2020/README.md
+++ b/changelog/2020/README.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade 2020 changelog — historical release notes, feature launches, and platform updates.
+---
+
 # 2020 Remote Collaboration: Essential Infrastructure for Distributed Teams
 
 **The Remote Work Revolution** - 20+ major releases make Taskade essential infrastructure for distributed teams worldwide, preparing the collaborative foundation for Taskade Genesis.

--- a/changelog/2021/README.md
+++ b/changelog/2021/README.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade 2021 changelog — historical release notes, feature launches, and platform updates.
+---
+
 # 2021 Major Redesigns: The Modern Foundation
 
 **Complete Platform Transformation** - Taskade V4 launches with modern interface and powerful features, preparing the foundation for AI integration and eventual Taskade Genesis.

--- a/changelog/2022/README.md
+++ b/changelog/2022/README.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade 2022 changelog — historical release notes, feature launches, and platform updates.
+---
+
 # 2022 AI & Automation: Think in Tasks, Not Prompts
 
 **The Arrival of Intelligence** - December 12th changes everything. AI becomes contextually aware of projects and tasks, laying the groundwork for Taskade Genesis.

--- a/changelog/2023/README.md
+++ b/changelog/2023/README.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade 2023 changelog — historical release notes, feature launches, and platform updates.
+---
+
 # 2023 AI Breakthrough: From Commands to Agents
 
 **The AI Transformation Year** - 18+ major AI releases. The evolution from AI assistant to intelligent teammates who think, learn, and collaborate.

--- a/changelog/2024/README.md
+++ b/changelog/2024/README.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade 2024 changelog — historical release notes, feature launches, and platform updates.
+---
+
 # 2024 Living DNA: Intelligence + Action + Knowledge + Evolution
 
 **The Breakthrough Year** - AI agents become autonomous teams. The four pillars of intelligent systems emerge to lay the foundation for Taskade Genesis.

--- a/changelog/2025/README.md
+++ b/changelog/2025/README.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade 2025 changelog — historical release notes, feature launches, and platform updates.
+---
+
 # 2025
 
 **From Static Apps to Living Systems** - The paradigm shift that transforms software from tools into intelligent companions powered by Workspace DNA.

--- a/contributing.md
+++ b/contributing.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Contribute to the Taskade documentation: fork the repo, edit Markdown, follow security and style guidelines, and submit a pull request to improve the docs.
+---
+
 # Contributing to Taskade Documentation
 
 This documentation is open source and we welcome contributions from the community. Whether you're fixing a typo, adding examples, or writing new sections, your help makes these docs better for everyone.

--- a/contributing/vision/README.md
+++ b/contributing/vision/README.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  The Taskade Genesis vision: the HyperCard of the AI era, letting anyone build powerful, AI-driven web apps with no code, no permission, no lock-in.
+---
+
 # Vision
 
 In 1987, Apple released HyperCard, a piece of software that fundamentally changed personal computing. For the first time, it gave non-programmers the power to create their own interactive software—from simple databases to complex adventure games—using a simple, card-based metaphor. It democratized creation.

--- a/contributing/vision/specs-and-interoperability.md
+++ b/contributing/vision/specs-and-interoperability.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Package projects, agents, automations, and templates into shareable Taskade AI Kits for one-click install, plus the planned .tsk standard and agent-friendly.
+---
+
 # Specs & Interoperability
 
 A core part of our vision is to create an open, interoperable ecosystem for AI-powered applications. We are moving toward a future where entire agentic systems can be version-controlled, shared, and remixed. Today, this vision is realized through **Taskade AI Kits**.

--- a/genesis-living-system-builder/ai-features/README.md
+++ b/genesis-living-system-builder/ai-features/README.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Deploy custom AI agents with persistent memory, knowledge, and tool access across your Taskade workspace — the intelligence layer behind every app and automation.
+  Deploy custom AI agents with persistent memory, knowledge, and tool access across your Taskade workspace — the intelligence layer behind every app and.
 ---
 
 # AI Features Overview

--- a/genesis-living-system-builder/ai-features/agent-knowledge.md
+++ b/genesis-living-system-builder/ai-features/agent-knowledge.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Train Taskade AI agents on your own knowledge: upload PDFs, CSVs, and docs, add URLs and YouTube, or connect projects as live, auto-updating sources.
+---
+
 # Agent Knowledge & Memory
 
 ---

--- a/genesis-living-system-builder/ai-features/agent-tools.md
+++ b/genesis-living-system-builder/ai-features/agent-tools.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Give Taskade AI agents real actions: add native tools, Slack/Gmail/HubSpot integrations, custom automation tools, and human-in-the-loop approvals.
+---
+
 # Tools for AI Agents
 
 ---

--- a/genesis-living-system-builder/ai-features/ai-agents-getting-started.md
+++ b/genesis-living-system-builder/ai-features/ai-agents-getting-started.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Create, train, and deploy Taskade AI agents that read your docs, answer questions, run tasks, and power multi-agent teams across your workspace.
+---
+
 # AI Agents Getting Started
 
 Transform your workspace with smart AI assistants that understand your business and can handle tasks automatically!

--- a/genesis-living-system-builder/ai-features/autopilot.md
+++ b/genesis-living-system-builder/ai-features/autopilot.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Use Taskade Autopilot to turn one prompt into a full workspace of connected projects, AI agents, agent teams, and automations, then expand it or build apps.
+---
+
 # Taskade Autopilot
 
 ---

--- a/genesis-living-system-builder/ai-features/image-generation.md
+++ b/genesis-living-system-builder/ai-features/image-generation.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Generate images for Taskade Genesis apps natively in EVE chat with ready-to-use prompt templates. Auto-saved to Media in 1:1, 16:9, or 9:16.
+---
+
 # Image Generation
 
 ---

--- a/genesis-living-system-builder/ai-features/media-ai-chat.md
+++ b/genesis-living-system-builder/ai-features/media-ai-chat.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Chat with your files, projects, and media in Taskade. Upload PDFs, images, CSVs, and videos, then ask questions, extract insights, and generate content with AI.
+---
+
 # Media AI Chat
 
 ---

--- a/genesis-living-system-builder/ai-features/multi-agents.md
+++ b/genesis-living-system-builder/ai-features/multi-agents.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Build teams of specialized AI agents in Taskade that collaborate on projects, with Taskade EVE orchestrating handoffs, multi-agent patterns, and shared chat.
+---
+
 # Multi-Agents
 
 ---

--- a/genesis-living-system-builder/automation/actions.md
+++ b/genesis-living-system-builder/automation/actions.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Complete Taskade automation action reference: create tasks, run AI agents, scrape web, send HTTP requests, integrate Slack, HubSpot, GitHub, and chain.
+---
+
 # Action & Trigger Reference
 
 Actions are the tasks that automations can perform. Each action connects to a specific service or system to create, update, or retrieve data. Actions can be chained together to create complex workflows.

--- a/genesis-living-system-builder/automation/advanced-actions.md
+++ b/genesis-living-system-builder/automation/advanced-actions.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Build advanced Taskade automations with loop and batch actions, WhatsApp Business messaging, HTTP schema generation, retries, and error handling.
+---
+
 # Advanced Automation Actions
 
 **Master the latest automation capabilities including loop processing, WhatsApp Business integration, AI-powered schema generation, and advanced error handling. These powerful features transform complex workflows into simple, reliable automations.**

--- a/genesis-living-system-builder/automation/ai-forms.md
+++ b/genesis-living-system-builder/automation/ai-forms.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Build Taskade AI Forms with smart validation, sentiment analysis, and conditional questions that auto-route responses into your workspace and CRM.
+---
+
 # AI Forms: Intelligent Data Collection
 
 **Create intelligent forms that think, adapt, and integrate seamlessly with your Taskade workspace. AI Forms go beyond traditional form builders by understanding context, validating responses intelligently, and automating follow-up actions.**

--- a/genesis-living-system-builder/automation/comprehensive-integration-guide.md
+++ b/genesis-living-system-builder/automation/comprehensive-integration-guide.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Connect Taskade to Slack, Gmail, HubSpot, Sheets and more with trigger-and-action automations, plus custom HTTP, webhook, and API integrations.
+---
+
 # Integration Overview
 
 **Transform isolated tools into intelligent, living ecosystems that learn, adapt, and evolve together.**

--- a/genesis-living-system-builder/automation/comprehensive-integrations.md
+++ b/genesis-living-system-builder/automation/comprehensive-integrations.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Full reference of Taskade automation triggers and actions across 30+ integrations: Slack, Gmail, Google Sheets, HubSpot, GitHub, AI agents, schedules.
+---
+
 # Comprehensive Integrations
 
 This document provides a complete reference of all available integrations, triggers, and actions in Taskade's automation system. For step-by-step guides, see the [Taskade Automation learn center](https://www.taskade.com/learn/automation). Every integration below also has a full setup page in the [Taskade Integrations directory](https://www.taskade.com/integrations).

--- a/genesis-living-system-builder/automation/integrations.md
+++ b/genesis-living-system-builder/automation/integrations.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Connect Taskade automations to 100+ tools like Slack, Gmail, GitHub, HubSpot, and Stripe with triggers and actions, plus custom webhook integrations.
+---
+
 # Supported Integrations
 
 Taskade connects to **100+ tools and services** across communication, productivity, AI, and developer ecosystems with enterprise-grade reliability and global performance. Each integration supports both triggers (events that start automations) and actions (tasks that automations can perform) with enhanced error handling and worldwide data synchronization.

--- a/genesis-living-system-builder/automation/recipes.md
+++ b/genesis-living-system-builder/automation/recipes.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Ready-to-use Taskade automation recipes with full JSON configs: AI blog publishing, social posting, lead capture, ticket routing, GitHub sync, and cart.
+---
+
 # Automation Recipes
 
 Real-world automation workflows that you can implement immediately. Each recipe includes the complete configuration, setup instructions, and customization options.

--- a/genesis-living-system-builder/automation/workflow-generator.md
+++ b/genesis-living-system-builder/automation/workflow-generator.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Build complex automations in Taskade from plain English: the Workflow Generator creates triggers, branches, loops, and 100+ integrations with no drag-and-drop.
+---
+
 # Workflow Generator
 
 ---

--- a/genesis-living-system-builder/community-and-sharing/best-practices.md
+++ b/genesis-living-system-builder/community-and-sharing/best-practices.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Best practices for building Taskade Genesis apps: write effective prompts, test on mobile, iterate one change at a time, and avoid common pitfalls.
+---
+
 # Best Practices for Genesis Success
 
 Learn from successful Taskade Genesis users to build better apps faster and avoid common pitfalls.

--- a/genesis-living-system-builder/community-and-sharing/faq.md
+++ b/genesis-living-system-builder/community-and-sharing/faq.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade Genesis FAQ: how the no-code app builder works, build times, publishing and custom domains, data ownership, security, integrations, and pricing.
+---
+
 # Living Systems FAQ
 
 ## Overview

--- a/genesis-living-system-builder/community-and-sharing/genesis-auth.md
+++ b/genesis-living-system-builder/community-and-sharing/genesis-auth.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Add secure user accounts and sign-in to Taskade Genesis apps with GenesisAuth: no-code App Users, workspace SSO, and custom-domain login.
+---
+
 # GenesisAuth
 
 A dedicated security layer for Taskade Genesis apps. Every Taskade Genesis app can ship with real user accounts and secure sign-in — no code, no third-party provider setup, no DevOps.

--- a/genesis-living-system-builder/community-and-sharing/publish-and-clone.md
+++ b/genesis-living-system-builder/community-and-sharing/publish-and-clone.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Publish, clone, and sell Taskade Genesis apps with live URLs, password protection, custom domains, SEO, white-label branding, and paid copies.
+---
+
 # Publish and Clone Your Apps
 
 ---

--- a/genesis-living-system-builder/community-and-sharing/troubleshooting.md
+++ b/genesis-living-system-builder/community-and-sharing/troubleshooting.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Fix a Taskade Genesis app that missed the mark: sharpen prompts, add missing features, match your brand, connect integrations, and resolve context-limit errors.
+---
+
 # Troubleshooting Your Genesis App
 
 Building with AI is like explaining your business to a really smart assistant who wants to help but sometimes needs more details. Don't worry if your first app isn't perfect - that's completely normal! Think of it as refining your idea until Taskade Genesis understands exactly what you need.

--- a/genesis-living-system-builder/genesis/README.md
+++ b/genesis-living-system-builder/genesis/README.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Taskade Genesis turns natural-language prompts into full applications — databases, interfaces, automations, and AI agents — deployed instantly from your workspace.
+  Taskade Genesis turns natural-language prompts into full applications — databases, interfaces, automations, and AI agents — deployed instantly from your.
 ---
 
 # Taskade Genesis Overview

--- a/genesis-living-system-builder/genesis/adding-context.md
+++ b/genesis-living-system-builder/genesis/adding-context.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Upload brand files, data, and reference docs as context so Taskade Genesis builds on-brand apps and enriches your Workspace DNA for future builds.
+---
+
 # Adding Genesis Context
 
 ---

--- a/genesis-living-system-builder/genesis/app-analytics.md
+++ b/genesis-living-system-builder/genesis/app-analytics.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Track visitors, pageviews, bounce rate, traffic sources, and devices for any published Taskade Genesis app with the built-in analytics dashboard, no extra.
+---
+
 # App Analytics
 
 ---

--- a/genesis-living-system-builder/genesis/debugging-genesis-apps.md
+++ b/genesis-living-system-builder/genesis/debugging-genesis-apps.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Debug Taskade Genesis apps with the Genesis Debugging Framework: classify failures, diagnose imports, routing, schema, and namespace bugs, and prevent.
+---
+
 # Debugging Genesis Apps
 
 ---

--- a/genesis-living-system-builder/genesis/examples-and-templates.md
+++ b/genesis-living-system-builder/genesis/examples-and-templates.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Copy proven Taskade Genesis prompts to build CRM dashboards, booking systems, forms, and landing pages in minutes, with 70+ live app templates to fork.
+---
+
 # Examples & Templates
 
 **Copy these proven prompts and build working business apps in minutes.**

--- a/genesis-living-system-builder/genesis/getting-started.md
+++ b/genesis-living-system-builder/genesis/getting-started.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Build your first app with Taskade Genesis in 5 minutes: turn a plain-English prompt into a working app, then test, refine, and publish it.
+---
+
 # Getting Started
 
 **Ready to build your first business app? This guide will take you from idea to working application in just 5 minutes.**

--- a/genesis-living-system-builder/genesis/github-import-export.md
+++ b/genesis-living-system-builder/genesis/github-import-export.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Import Taskade Genesis apps from GitHub repos and export them back via branch-and-PR flows for version-controlled, two-way app sync.
+---
+
 # GitHub Import & Export
 
 Bring Taskade Genesis apps in from GitHub repositories and push your apps back to GitHub with branch-and-PR workflows. Two-way sync turns every Genesis app into a portable, version-controlled kit.

--- a/genesis-living-system-builder/genesis/how-genesis-works.md
+++ b/genesis-living-system-builder/genesis/how-genesis-works.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  How Taskade Genesis turns plain-English prompts into live apps using Workspace DNA: projects, AI agents, automations, EVE, and Intelligence Score.
+---
+
 # How Genesis Works: Workspace DNA
 
 ---

--- a/genesis-living-system-builder/genesis/prompt-guide.md
+++ b/genesis-living-system-builder/genesis/prompt-guide.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Write better Taskade Genesis prompts with 12 principles: set objectives, describe outcomes, connect tools, define access, and iterate to build the app you.
+---
+
 # A Maker's Guide to AI Prompts
 
 ---

--- a/genesis-living-system-builder/genesis/version-history.md
+++ b/genesis-living-system-builder/genesis/version-history.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  View, compare, and restore Taskade Genesis app versions. Every change is a full snapshot, with auto vs manual publish controls and Code View.
+---
+
 # Genesis Version History
 
 ---

--- a/genesis-living-system-builder/run-your-business/build-an-ops-dashboard.md
+++ b/genesis-living-system-builder/run-your-business/build-an-ops-dashboard.md
@@ -1,8 +1,6 @@
 ---
 description: >-
-  Build an internal ops dashboard, CRM, or pipeline your whole team logs into —
-  describe it to Taskade Genesis, connect live workspace data, and let people in with the
-  Taskade identity they already have.
+  Build an internal ops dashboard, CRM, or pipeline your team logs into — describe it to Taskade Genesis, connect live workspace data, and add logins.
 keywords: ops dashboard, internal tool, CRM, pipeline, no-code
 ---
 

--- a/genesis-living-system-builder/space-apps-guide/advanced-features.md
+++ b/genesis-living-system-builder/space-apps-guide/advanced-features.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Advanced Taskade Genesis features: smart data structures, AI agent training, multi-step automations, integrations, access control, version history, and.
+---
+
 # Advanced Features
 
 Ready to take your Taskade Genesis app to the next level? These powerful features help you build even smarter and more capable applications. No coding required—just plain English descriptions of what you want!

--- a/genesis-living-system-builder/space-apps-guide/genesis-prompt-library.md
+++ b/genesis-living-system-builder/space-apps-guide/genesis-prompt-library.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Copy-paste Taskade Genesis prompts by business function: CRM, ops, sales, scheduling, plus styling and anatomy tips for building better apps faster.
+---
+
 # Intelligent Prompt Library
 
 Master Taskade Genesis with proven prompts organized by business function. Copy, paste, and customize these prompts to build your perfect app in minutes.

--- a/genesis-living-system-builder/workspaces/advanced-search-navigation.md
+++ b/genesis-living-system-builder/workspaces/advanced-search-navigation.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Find anything in Taskade fast with global search, smart filters, search operators, natural-language queries, the command palette, and keyboard navigation.
+---
+
 # Advanced Search & Discovery
 
 Master Taskade's powerful search capabilities and navigation features to quickly find information, projects, and content across your entire workspace ecosystem.

--- a/genesis-living-system-builder/workspaces/collaboration.md
+++ b/genesis-living-system-builder/workspaces/collaboration.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Collaborate in real time on Taskade with live co-editing, team chat, comments, video calls, presence, and async tools plus AI summaries and version history.
+---
+
 # Collaboration: Team Intelligence
 
 Taskade enables seamless real-time and asynchronous collaboration across teams. Use chat, video, presence, and comments to stay aligned while work happens in projects, agents, and automations.

--- a/genesis-living-system-builder/workspaces/editing-formatting.md
+++ b/genesis-living-system-builder/workspaces/editing-formatting.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Format Taskade tasks with headings, lists, highlights, and 8 project views, plus add-ons like due dates, timers, and keyboard shortcuts.
+---
+
 # Editing & Formatting
 
 ---

--- a/genesis-living-system-builder/workspaces/embed.md
+++ b/genesis-living-system-builder/workspaces/embed.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Embed Taskade projects and Genesis apps on any site via iframe, set theme and size, and embed Google Docs, Figma, Loom, YouTube inside projects.
+---
+
 # Embed Taskade
 
 ---

--- a/genesis-living-system-builder/workspaces/import.md
+++ b/genesis-living-system-builder/workspaces/import.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Import Markdown, PDF, Word, Excel, CSV, and more into Taskade projects, or add files as AI agent knowledge, project context, and Taskade Genesis app context.
+---
+
 # Import
 
 ---

--- a/genesis-living-system-builder/workspaces/knowledge-management.md
+++ b/genesis-living-system-builder/workspaces/knowledge-management.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Upload, organize, and manage knowledge sources in Taskade to power smarter AI agents, with bulk import, auto-categorization, and the Agents API.
+---
+
 # Knowledge Organization
 
 **Transform your scattered information into organized, searchable intelligence that powers smarter AI agents and more effective workflows. Learn how to efficiently upload, organize, and manage knowledge sources for maximum AI performance.**

--- a/genesis-living-system-builder/workspaces/markdown.md
+++ b/genesis-living-system-builder/workspaces/markdown.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Use Markdown in Taskade across the project editor, chat, comments, AI agent chat, import/export, and widgets. Full syntax reference for headings, lists, and.
+---
+
 # Markdown Support
 
 ---

--- a/genesis-living-system-builder/workspaces/mobile-optimization.md
+++ b/genesis-living-system-builder/workspaces/mobile-optimization.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Build mobile-first Taskade Genesis apps and workflows: iOS/Android apps, PWA, offline sync, Quick Add widget, voice, and responsive design across devices.
+---
+
 # Mobile Living Experience
 
 **Master Taskade's mobile-first features and create apps that work beautifully across all devices. From responsive Taskade Genesis apps to native mobile workflows, ensure your users have a seamless experience whether they're on desktop, tablet, or phone.**

--- a/genesis-living-system-builder/workspaces/project-views.md
+++ b/genesis-living-system-builder/workspaces/project-views.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Switch Taskade projects between List, Board, Table, Calendar, Mind Map, Gantt, and more views on the same data, plus custom field types and Fill with AI.
+---
+
 # Project Views Explained
 
 Taskade stores information in a flexible tree-structured database. The **same data** can be visualized in multiple ways to suit different workflows. These presentation modes are called **Project Views**.

--- a/genesis-living-system-builder/workspaces/projects-databases.md
+++ b/genesis-living-system-builder/workspaces/projects-databases.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Build Taskade database projects: custom fields, relationships, and 8 views. See how Genesis auto-generates schemas that power apps, agents, and automations.
+---
+
 # Projects & Databases: The Memory Pillar
 
 ---

--- a/genesis-living-system-builder/workspaces/teams.md
+++ b/genesis-living-system-builder/workspaces/teams.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Organize Taskade for teams with workspace, folder, and function structures, a 5-role RBAC permission system, and AI-powered team features.
+---
+
 # Taskade for Teams
 
 ---

--- a/help-and-support/comprehensive-troubleshooting-guide.md
+++ b/help-and-support/comprehensive-troubleshooting-guide.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Fix common Taskade issues: login and 2FA, sync, slow performance, AI agents, automations, mobile, integrations, and network blocks, step by step.
+---
+
 # Troubleshooting Guide
 
 Resolve common Taskade issues quickly with our comprehensive troubleshooting guide covering everything from basic connectivity problems to advanced workflow debugging.

--- a/help-and-support/index/01_workspaces.md
+++ b/help-and-support/index/01_workspaces.md
@@ -1,7 +1,6 @@
 ---
-title: 'Chapter 1: Workspaces - The Living Foundation'
-parent: 'Taskade: The Living DNA Productivity Platform'
-nav_order: 1
+description: >-
+  Understand Taskade workspaces: the foundation that organizes projects, AI agents, and automations. Learn spaces, hierarchy, workspace types, settings, and.
 ---
 
 # Chapter 1: Workspaces - The Foundation

--- a/help-and-support/index/02_projects.md
+++ b/help-and-support/index/02_projects.md
@@ -1,4 +1,6 @@
 ---
+description: >-
+  Taskade projects are flexible data containers viewable 8 ways: List, Board, Table, Calendar, Mind Map, Org Chart, Gantt, and Action views.
 title: 'Chapter 2: Projects - Your Data Containers'
 parent: 'Taskade: The Living DNA Productivity Platform'
 nav_order: 2

--- a/help-and-support/index/03_ai_agents.md
+++ b/help-and-support/index/03_ai_agents.md
@@ -1,4 +1,6 @@
 ---
+description: >-
+  Build AI agents in Taskade as specialized digital team members. Define a role, train on your knowledge, test, and deploy agents for support, sales, and.
 title: 'Chapter 3: AI Agents - Your Digital Team'
 parent: 'Taskade: The Living DNA Productivity Platform'
 nav_order: 3

--- a/help-and-support/index/04_automation.md
+++ b/help-and-support/index/04_automation.md
@@ -1,4 +1,6 @@
 ---
+description: >-
+  Build Taskade automations with triggers, conditions, and actions: connect projects, AI agents, and 100+ tools to handle repetitive work and follow-ups.
 title: 'Chapter 4: Automation - Workflows on Autopilot'
 parent: 'Taskade: The Living DNA Productivity Platform'
 nav_order: 4

--- a/help-and-support/index/05_genesis.md
+++ b/help-and-support/index/05_genesis.md
@@ -1,4 +1,6 @@
 ---
+description: >-
+  Build complete business apps from a plain-English description with Taskade Genesis: auto-generated databases, UIs, AI assistants, automations, and instant.
 title: 'Chapter 5: Taskade Genesis - Building Apps with AI'
 parent: 'Taskade: The Living DNA Productivity Platform'
 nav_order: 5

--- a/help-and-support/index/06_integrations.md
+++ b/help-and-support/index/06_integrations.md
@@ -1,4 +1,6 @@
 ---
+description: >-
+  Connect Taskade to 100+ tools like Slack, Google Workspace, HubSpot, and GitHub for two-way data sync, event triggers, and AI-orchestrated workflows.
 title: 'Chapter 6: Integrations - Connecting Your Tools'
 parent: 'Taskade: The Living DNA Productivity Platform'
 nav_order: 6

--- a/help-and-support/index/07_api.md
+++ b/help-and-support/index/07_api.md
@@ -1,4 +1,6 @@
 ---
+description: >-
+  Get started with the Taskade REST API: authenticate with a token, call workspace, project, and task endpoints, and wire up webhooks and the MCP server.
 title: 'Chapter 7: API - Developer Interfaces'
 parent: 'Taskade: The Living DNA Productivity Platform'
 nav_order: 7

--- a/help-and-support/index/08_mobile_desktop.md
+++ b/help-and-support/index/08_mobile_desktop.md
@@ -1,4 +1,6 @@
 ---
+description: >-
+  Use Taskade across iOS, Android, Mac, Windows, Linux, and web with real-time sync, offline mode, voice commands, widgets, and browser extensions.
 title: 'Chapter 8: Mobile & Desktop - Cross-Platform Productivity'
 parent: 'Taskade: The Living DNA Productivity Platform'
 nav_order: 8

--- a/help-and-support/index/README.md
+++ b/help-and-support/index/README.md
@@ -1,8 +1,6 @@
 ---
-layout: default
-title: "Taskade: The Living DNA Productivity Platform"
-nav_order: 1
-has_children: true
+description: >-
+  Beginner tutorial to Taskade: workspaces, projects, AI agents, automation, Taskade Genesis app building, integrations, the API, and cross-platform apps.
 ---
 
 # Tutorial: Taskade - The Living DNA Productivity Platform

--- a/help-center/import-and-export.md
+++ b/help-center/import-and-export.md
@@ -1,8 +1,6 @@
 ---
 description: >-
-  Bring your existing work into Taskade and take it with you anywhere.
-  Step-by-step guide for importing files, migrating from other tools, and
-  exporting your projects.
+  Bring your existing work into Taskade and take it with you anywhere. Step-by-step guide for importing files, migrating from other tools, and exporting your.
 ---
 
 # Import & Export

--- a/updates-and-timeline/changelog-2026/README.md
+++ b/updates-and-timeline/changelog-2026/README.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade 2026 developer changelog — monthly API, MCP, automation, agents, and Taskade Genesis platform updates.
+---
+
 # Changelog (2026)
 
 Developer-focused highlights of API, MCP, SDK, automation, and Taskade Genesis platform changes shipped in 2026. For releases before 2026, see the [Changelog archive](../../changelog/README.md).

--- a/updates-and-timeline/changelog-2026/april-2026/README.md
+++ b/updates-and-timeline/changelog-2026/april-2026/README.md
@@ -1,4 +1,6 @@
 ---
+description: >-
+  Taskade developer changelog for April 2026 — API, MCP, automation, agents, and Taskade Genesis updates.
 cover: ../../../.gitbook/assets/Changlog_Banner_Apr.png
 coverY: 0
 ---

--- a/updates-and-timeline/changelog-2026/april-2026/april-10-2026.md
+++ b/updates-and-timeline/changelog-2026/april-2026/april-10-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — April 10, 2026: New Taskade Genesis Authentication for Apps, Tool Calls Feature for App and Public Agents.
+---
+
 # April 10, 2026
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/april-2026/april-13-2026.md
+++ b/updates-and-timeline/changelog-2026/april-2026/april-13-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — April 13, 2026: Export Projects to Markdown, Authenticated MCP Servers.
+---
+
 # April 13, 2026
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/april-2026/april-15-2026.md
+++ b/updates-and-timeline/changelog-2026/april-2026/april-15-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — April 15, 2026: Stripe Checkout for Apps, Import Appkits from Private Repos & Push Appkit Updates to Github.
+---
+
 # April 15, 2026
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/april-2026/april-16-2026.md
+++ b/updates-and-timeline/changelog-2026/april-2026/april-16-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — April 16, 2026: Bash Sandbox for Taskade EVE.
+---
+
 # April 16, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/april-2026/april-17-2026.md
+++ b/updates-and-timeline/changelog-2026/april-2026/april-17-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — April 17, 2026: New LLM Models Added to the Picker, EVE Custom Bash Commands.
+---
+
 # April 17, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/april-2026/april-2-2026.md
+++ b/updates-and-timeline/changelog-2026/april-2026/april-2-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — April 2, 2026: Google Calendar Actions, Responsive Genesis Apps.
+---
+
 # April 2, 2026
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/april-2026/april-22-2026.md
+++ b/updates-and-timeline/changelog-2026/april-2026/april-22-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — April 22, 2026: Improved Onboarding for New Users, Updated LLM Models.
+---
+
 # April 22, 2026
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/april-2026/april-23-2026.md
+++ b/updates-and-timeline/changelog-2026/april-2026/april-23-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — April 23, 2026: Generic Webhook Trigger (HTTP Piece) — GA, Mailhook Trigger — Now Free on All Plans.
+---
+
 # April 23, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/april-2026/april-28-2026.md
+++ b/updates-and-timeline/changelog-2026/april-2026/april-28-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — April 28, 2026: New "Manual" Liquid Expression for Webhooks, Multiple New Action Pieces for Automations.
+---
+
 # April 28, 2026
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/april-2026/april-29-2026.md
+++ b/updates-and-timeline/changelog-2026/april-2026/april-29-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — April 29, 2026.
+---
+
 # April 29, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/april-2026/april-30-2026.md
+++ b/updates-and-timeline/changelog-2026/april-2026/april-30-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — April 30, 2026: Additional Automation Actions, New LLM Models: Qwen 3.6 Max, Kimi K2.6, DeepSeek V4.
+---
+
 # April 30, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/april-2026/april-6-2026.md
+++ b/updates-and-timeline/changelog-2026/april-2026/april-6-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — April 6, 2026: Meet Taskade EVE's new commands, Improved in-app UI for AI Agents created by Taskade EVE.
+---
+
 # April 6, 2026
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/april-2026/april-8-2026.md
+++ b/updates-and-timeline/changelog-2026/april-2026/april-8-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — April 8, 2026: MCP Server (Beta), Taskade SDK.
+---
+
 # April 8, 2026
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/february-2026/README.md
+++ b/updates-and-timeline/changelog-2026/february-2026/README.md
@@ -1,4 +1,6 @@
 ---
+description: >-
+  Taskade developer changelog for February 2026 — API, MCP, automation, agents, and Taskade Genesis updates.
 cover: ../../../.gitbook/assets/Changlog_Banner_Feb.png
 coverY: 0
 layout:

--- a/updates-and-timeline/changelog-2026/february-2026/february-12-2026.md
+++ b/updates-and-timeline/changelog-2026/february-2026/february-12-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — February 12, 2026: Upgrades to Agent Chat.
+---
+
 # February 12, 2026
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/february-2026/february-13-2026.md
+++ b/updates-and-timeline/changelog-2026/february-2026/february-13-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — February 13, 2026: Agent Public API, Hosted MCP v2.
+---
+
 # February 13, 2026
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/february-2026/february-16-2026.md
+++ b/updates-and-timeline/changelog-2026/february-2026/february-16-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — February 16, 2026: Public API v2 — Preview, Experimental MCP v2 — Auto-Generated Tool Layer.
+---
+
 # February 16, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/february-2026/february-18-2026.md
+++ b/updates-and-timeline/changelog-2026/february-2026/february-18-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — February 18, 2026: Automation: Retry-After Header Support for 429 Responses, Automation: Flow-Enable Idempotency.
+---
+
 # February 18, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/february-2026/february-19-2026.md
+++ b/updates-and-timeline/changelog-2026/february-2026/february-19-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — February 19, 2026: Top Creators.
+---
+
 # February 19, 2026
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/february-2026/february-2-2026.md
+++ b/updates-and-timeline/changelog-2026/february-2026/february-2-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — February 2, 2026: Integrations Directory, Custom Agent Tools & Commands.
+---
+
 # February 2, 2026
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/february-2026/february-23-2026.md
+++ b/updates-and-timeline/changelog-2026/february-2026/february-23-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — February 23, 2026: Upgraded LLM Models, New Shopify Actions.
+---
+
 # February 23, 2026
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/february-2026/february-25-2026.md
+++ b/updates-and-timeline/changelog-2026/february-2026/february-25-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — February 25, 2026.
+---
+
 # February 25, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/february-2026/february-27-2026.md
+++ b/updates-and-timeline/changelog-2026/february-2026/february-27-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — February 27, 2026: Hosted MCP v2 — OAuth 2.0 PKCE + Dynamic Client Registration, New Automation Piece: Telegram Bot.
+---
+
 # February 27, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/february-2026/february-6-2026.md
+++ b/updates-and-timeline/changelog-2026/february-2026/february-6-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — February 6, 2026: Updated Open Graph Images, Space Icon -> Favicons.
+---
+
 # February 6, 2026
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/january-2026/README.md
+++ b/updates-and-timeline/changelog-2026/january-2026/README.md
@@ -1,4 +1,6 @@
 ---
+description: >-
+  Taskade developer changelog for January 2026 — API, MCP, automation, agents, and Taskade Genesis updates.
 cover: ../../../.gitbook/assets/Changlog_Banner_Jan (1).png
 coverY: 0
 layout:

--- a/updates-and-timeline/changelog-2026/january-2026/january-13-2026.md
+++ b/updates-and-timeline/changelog-2026/january-2026/january-13-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — January 13, 2026: Updated Main Genesis Page, Quick Access Delete.
+---
+
 # January 13, 2026
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/january-2026/january-16-2026.md
+++ b/updates-and-timeline/changelog-2026/january-2026/january-16-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — January 16, 2026.
+---
+
 # January 16, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/january-2026/january-19-2026.md
+++ b/updates-and-timeline/changelog-2026/january-2026/january-19-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — January 19, 2026: UI Element Selector, Agents UI Refresh.
+---
+
 # January 19, 2026
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/january-2026/january-2-2026.md
+++ b/updates-and-timeline/changelog-2026/january-2026/january-2-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — January 2, 2026: Shopify — "Get Customer Order" Automation Action, Genesis App Authentication — Space Identities Foundation.
+---
+
 # January 2, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/january-2026/january-22-2026.md
+++ b/updates-and-timeline/changelog-2026/january-2026/january-22-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — January 22, 2026: New Appgen Loading Screen.
+---
+
 # January 22, 2026
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/january-2026/january-28-2026.md
+++ b/updates-and-timeline/changelog-2026/january-2026/january-28-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — January 28, 2026: New Publish Flow, New Community "New" Tab.
+---
+
 # January 28, 2026
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/january-2026/january-29-2026.md
+++ b/updates-and-timeline/changelog-2026/january-2026/january-29-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — January 29, 2026: Space Agent Tool Calls v2 — Automation Actions as Agent Tools, Space Agents — Projects & Knowledge…
+---
+
 # January 29, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/january-2026/january-30-2026.md
+++ b/updates-and-timeline/changelog-2026/january-2026/january-30-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — January 30, 2026: Taskade EVE can now use Leaflet maps, Check out our Credits & Rewards system.
+---
+
 # January 30, 2026
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/january-2026/january-6-2026.md
+++ b/updates-and-timeline/changelog-2026/january-2026/january-6-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — January 6, 2026: Credits Purchase.
+---
+
 # January 6, 2026
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/january-2026/january-9-2026.md
+++ b/updates-and-timeline/changelog-2026/january-2026/january-9-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — January 9, 2026: Email Trigger Reliability — Mailhook Schema Fix, Custom Domain — Health Check Middleware Fix.
+---
+
 # January 9, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/june-2026/README.md
+++ b/updates-and-timeline/changelog-2026/june-2026/README.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog for June 2026 — API, MCP, automation, agents, and Taskade Genesis updates.
+---
+
 # June 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/june-2026/june-1-2026.md
+++ b/updates-and-timeline/changelog-2026/june-2026/june-1-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — June 1, 2026: Delegated Custom-Domain Validation, MiniMax M3 Model.
+---
+
 # June 1, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/june-2026/june-14-2026.md
+++ b/updates-and-timeline/changelog-2026/june-2026/june-14-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — June 14, 2026: New Connectors: Microsoft Outlook, Todoist, ClickUp, Google Tasks, Google Docs, Connector Expansions.
+---
+
 # June 14, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/june-2026/june-19-2026.md
+++ b/updates-and-timeline/changelog-2026/june-2026/june-19-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — June 19, 2026: Utilities Piece: Data Transform Actions, Utilities Piece: Number Summaries.
+---
+
 # June 19, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/june-2026/june-22-2026.md
+++ b/updates-and-timeline/changelog-2026/june-2026/june-22-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — June 22, 2026: EVE Can Run a Saved Automation, EVE Can Build an Automation From a Template.
+---
+
 # June 22, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/june-2026/june-23-2026.md
+++ b/updates-and-timeline/changelog-2026/june-2026/june-23-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — June 23, 2026: Attach File to Task Action.
+---
+
 # June 23, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/june-2026/june-3-2026.md
+++ b/updates-and-timeline/changelog-2026/june-2026/june-3-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — June 3, 2026: Currency Field Type in Database, Qwen 3.7 Plus Model.
+---
+
 # June 3, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/june-2026/june-4-2026.md
+++ b/updates-and-timeline/changelog-2026/june-2026/june-4-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — June 4, 2026: Table View Multi-Select and Bulk Delete, Public Share URLs for Table View.
+---
+
 # June 4, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/june-2026/june-5-2026.md
+++ b/updates-and-timeline/changelog-2026/june-2026/june-5-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — June 5, 2026: Published Apps Are Private by Default, Papaparse Available in Base App Templates.
+---
+
 # June 5, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/june-2026/june-9-2026.md
+++ b/updates-and-timeline/changelog-2026/june-2026/june-9-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — June 9, 2026: Docs (Beta) and List View in Production, Inbound Webhooks for Pro+ Plans.
+---
+
 # June 9, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/march-2026/README.md
+++ b/updates-and-timeline/changelog-2026/march-2026/README.md
@@ -1,4 +1,6 @@
 ---
+description: >-
+  Taskade developer changelog for March 2026 — API, MCP, automation, agents, and Taskade Genesis updates.
 cover: ../../../.gitbook/assets/Changlog_Banner_Mar.png
 coverY: 0
 ---

--- a/updates-and-timeline/changelog-2026/march-2026/march-10-2026.md
+++ b/updates-and-timeline/changelog-2026/march-2026/march-10-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — March 10, 2026: OpenAI GPT-5.3 Codex, Inline Theme Bar.
+---
+
 # March 10, 2026
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/march-2026/march-11-2026.md
+++ b/updates-and-timeline/changelog-2026/march-2026/march-11-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — March 11, 2026: PKCE Enabled for All Flow OAuth2 Integrations, Custom Domain SSL: Delegated DCV + Reliability Improvements.
+---
+
 # March 11, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/march-2026/march-13-2026.md
+++ b/updates-and-timeline/changelog-2026/march-2026/march-13-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — March 13, 2026: Import & Export your Taskade Apps, \[Mobile] New EVE Chat Drawer.
+---
+
 # March 13, 2026
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/march-2026/march-16-2026.md
+++ b/updates-and-timeline/changelog-2026/march-2026/march-16-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — March 16, 2026: Security Hardening for API Integrators and Credential Holders.
+---
+
 # March 16, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/march-2026/march-19-2026.md
+++ b/updates-and-timeline/changelog-2026/march-2026/march-19-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — March 19, 2026: New Pieces for Automations, \[Mobile] Improved AI Agent Chat UX.
+---
+
 # March 19, 2026
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/march-2026/march-2-2026.md
+++ b/updates-and-timeline/changelog-2026/march-2026/march-2-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — March 2, 2026: New Telegram Bot Actions, Set Open Graph Image.
+---
+
 # March 2, 2026
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/march-2026/march-22-2026.md
+++ b/updates-and-timeline/changelog-2026/march-2026/march-22-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — March 22, 2026: MCP SDK Upgraded to ^1.27.1 / mcp-proxy ^6.4.4, Agent Memory Available Across All LLM Models.
+---
+
 # March 22, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/march-2026/march-26-2026.md
+++ b/updates-and-timeline/changelog-2026/march-2026/march-26-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — March 26, 2026: Appkit Template UI Refresh, New Pieces for Automations.
+---
+
 # March 26, 2026
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/march-2026/march-28-2026.md
+++ b/updates-and-timeline/changelog-2026/march-2026/march-28-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — March 28, 2026: @taskade/embed Migrated into Monorepo with Security Hardening, HSTS Header Configured Explicitly for API…
+---
+
 # March 28, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/march-2026/march-31-2026.md
+++ b/updates-and-timeline/changelog-2026/march-2026/march-31-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — March 31, 2026: New v8 Max and Enterprise plans, Github Importing and Exporting of Appkits.
+---
+
 # March 31, 2026
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/march-2026/march-5-2026.md
+++ b/updates-and-timeline/changelog-2026/march-2026/march-5-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — March 5, 2026: Media Browse Tab, Auto Top-Up Credits.
+---
+
 # March 5, 2026
 
 ## What's New:

--- a/updates-and-timeline/changelog-2026/march-2026/march-9-2026.md
+++ b/updates-and-timeline/changelog-2026/march-2026/march-9-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — March 9, 2026.
+---
+
 # March 9, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/may-2026/README.md
+++ b/updates-and-timeline/changelog-2026/may-2026/README.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog for May 2026 — API, MCP, automation, agents, and Taskade Genesis updates.
+---
+
 # May 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/may-2026/may-1-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-1-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — May 1, 2026: Project List Bulk Delete, BYOK (Bring Your Own Key) for Agents — Enterprise.
+---
+
 # May 1, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/may-2026/may-11-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-11-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — May 11, 2026: Paid Apps — Sell Published Genesis Apps via Stripe.
+---
+
 # May 11, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/may-2026/may-12-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-12-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — May 12, 2026: Async Bundle Import/Export for Large Apps, TAA Can Enable MCP Tools During Genesis Generation.
+---
+
 # May 12, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/may-2026/may-13-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-13-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — May 13, 2026: App Clone Ancestry Tracking.
+---
+
 # May 13, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/may-2026/may-14-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-14-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — May 14, 2026: Image Format Conversion Automation Action, Structured 'Run Agent' Command Output.
+---
+
 # May 14, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/may-2026/may-18-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-18-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — May 18, 2026: Unified Template Browsing Experience.
+---
+
 # May 18, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/may-2026/may-20-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-20-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — May 20, 2026: New Models Added — Gemini 3.5 Flash and More.
+---
+
 # May 20, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/may-2026/may-22-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-22-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — May 22, 2026: New Models Added — Qwen 3.7 Max, Grok Build 0.1, and More.
+---
+
 # May 22, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/may-2026/may-26-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-26-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — May 26, 2026: App Secrets Vault, Outbound Proxy for External API Calls.
+---
+
 # May 26, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/may-2026/may-28-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-28-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — May 28, 2026: Create Automations Directly from Agents, Teams, and Media, App Categories for Published Apps.
+---
+
 # May 28, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/may-2026/may-29-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-29-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — May 29, 2026: Delegated DCV for Custom Domains, New Models Added — Claude Opus 4.8, Xiaomi Mimo, and More.
+---
+
 # May 29, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/may-2026/may-4-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-4-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — May 4, 2026: Knowledge-Base Citations in Agent Chat, `?mode=template` Share Parameter.
+---
+
 # May 4, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/may-2026/may-5-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-5-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — May 5, 2026: Bearer-Token Authentication for Webhook Triggers, New Frontier LLMs Available.
+---
+
 # May 5, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/may-2026/may-6-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-6-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — May 6, 2026: `/settings/api` — Centralized API Hub, New Automation Triggers: Project Created and Due Date Removed.
+---
+
 # May 6, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/may-2026/may-7-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-7-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — May 7, 2026: Shopify Connector — OAuth2.
+---
+
 # May 7, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/changelog-2026/may-2026/may-8-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-8-2026.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Taskade developer changelog — May 8, 2026: BYOK Verify-on-Save.
+---
+
 # May 8, 2026
 
 {% hint style="info" %}

--- a/updates-and-timeline/upcoming-changes.md
+++ b/updates-and-timeline/upcoming-changes.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  Find upcoming Taskade changes and the latest product updates on the official Taskade changelog at taskade.com/changelog.
+---
+
 # Upcoming Changes
 
 For all future upcoming changes, please visit our new changelog at:


### PR DESCRIPTION
## Meta descriptions for every page (SEO + AEO)

Adds a frontmatter `description` to all rendered pages — **212 were missing one; now 250/250**. GitBook uses `description` for both the page's `<meta name="description">` (SEO) **and** its entry in the auto-generated `/llms.txt` (AEO — what AI answer engines ingest), so this is a double win. **Zero rendering regression** (0 broken links/anchors vs `main`; all YAML valid; every description answer-first and ≤160 chars for full search display).

- **API reference (66) + changelog (~92):** templated, each unique — e.g. "Create Project — Taskade REST API v1 reference: POST /projects…", "Taskade developer changelog — April 10, 2026: …".
- **Content pages (62):** individually crafted — answer-first, keyword-rich, accurate (no invented claims), distinct per page.
- Uses full product names (Taskade Genesis / Taskade EVE); each ≤160 chars.

### Context: AEO freebies already active on this site
`/llms.txt` + `/llms-full.txt` are served, the sitemap is published, and `robots.txt` carries AI content-signals (`ai-train=yes, search=yes, ai-input=yes`). These descriptions make the `llms.txt` entries substantive instead of empty.

cc @deanzaka @lxcid
