### PR TITLE
docs(developers): fix dead token + OAuth registration URL (/settings/password -> /settings/api)

### DIFF
--- a/apis-living-system-development/developers/authentication.md
+++ b/apis-living-system-development/developers/authentication.md
@@ -68,7 +68,7 @@ Use OAuth 2.0 when your application acts **on behalf of other users** (so each u
 
 ### Register an application
 
-Go to [taskade.com/settings/password](https://www.taskade.com/settings/password) → **OAuth 2.0 Apps** and register your app to obtain a **Client ID** and **Client Secret**, and to set your redirect URI(s).
+Go to [taskade.com/settings/api](https://www.taskade.com/settings/api) → **OAuth 2.0 Apps** and register your app to obtain a **Client ID** and **Client Secret**, and to set your redirect URI(s).
 
 ### Authorization Code flow (with PKCE)
 

--- a/apis-living-system-development/developers/personal-tokens.md
+++ b/apis-living-system-development/developers/personal-tokens.md
@@ -14,7 +14,7 @@ Personal Access Tokens are unique strings that represent your authorization to a
 ## Steps to Obtain and Use a Personal Access Token:
 
 1. **Generate a Token:**
-   * Navigate to [https://taskade.com/settings/password](https://taskade.com/settings/password) and scroll down to **Personal Access Tokens**.
+   * Navigate to [https://www.taskade.com/settings/api](https://www.taskade.com/settings/api) and scroll down to **Personal Access Tokens**.
    * Follow the on-screen instructions to create your personal access token.
 2. **Using the Token in API Requests:**
    *   Once you have your token, include it in the header of your API requests. Typically, this is done using the `Authorization` header. For example:


### PR DESCRIPTION
## Summary

Two developer pages point operators to `https://taskade.com/settings/password` to find their Personal Access Token / register an OAuth app. That's the **password** page — the token hub moved to `https://www.taskade.com/settings/api`. A first-time user follows the link, lands on the wrong page, can't find their token, and abandons setup. This fixes the very first door.

## What changed

| File | Before | After |
|------|--------|-------|
| `developers/personal-tokens.md` (L~17) | `https://taskade.com/settings/password` (text + href) | `https://www.taskade.com/settings/api` |
| `developers/authentication.md` (L~71, OAuth app registration) | `[taskade.com/settings/password](https://www.taskade.com/settings/password)` | `[taskade.com/settings/api](https://www.taskade.com/settings/api)` |

## Why it matters

The token URL is the literal first step of MCP setup. A dead-end here loses the user before they ever connect. The `taskade/mcp` repo already uses `/settings/api` everywhere — this is the docs catching up.

## Verification / zero-regression

- Scoped strictly to the `/settings/password` occurrences. The bare `taskade.com/mcp` endpoint strings in `authentication.md` are intentionally left for PR **D3** (endpoint normalization) — no overlap.

## Merge order

Independent of all other PRs except a soft overlap with **D3** on `authentication.md` (different lines). Either order merges cleanly.

---
Part of the docs-led dual-repo MCP roadmap. Canonical token page: `https://www.taskade.com/settings/api`.

🤖 Authored with Claude Code (multi-agent verified)
