### PR TITLE
docs(mcp): Workspace MCP — 62 tools + v2 agent-chat/webhooks (fix stale 57-tool/no-prompt-agent claims)

### DIFF
--- a/apis-living-system-development/workspace-mcp-advanced.md
+++ b/apis-living-system-development/workspace-mcp-advanced.md
@@ -197,7 +197,7 @@ Plan features may evolve. Check the [pricing page](https://www.taskade.com/prici
 
 ## Tool Catalog Details
 
-The inbound server exposes **57 tools** across 7 categories whose names mirror the [REST API v1](comprehensive-api-guide/README.md) operations it wraps. Below are the ones integrators most often need to configure precisely.
+The inbound server exposes **62 tools** across 8 categories whose names mirror the [REST API v1](comprehensive-api-guide/README.md) operations it wraps, plus a small **Agent Chat & Webhooks (API v2, beta)** group (`promptAgent`, `listConversations`, `getConversation`, `subscribeWebhook`, `unsubscribeWebhook`). Below are the ones integrators most often need to configure precisely.
 
 ### `projectTasksGet`
 
@@ -216,7 +216,7 @@ The inbound server exposes **57 tools** across 7 categories whose names mirror t
 - **`agentConvoGet`** returns one conversation (`agentId`, `convoId`).
 
 {% hint style="info" %}
-This local server wraps **v1** and therefore has **no prompt-an-agent tool**. To prompt agents programmatically, call [`POST /api/v2/promptAgent`](api-v2-reference.md#prompt-an-agent) directly, or use the agent inside Taskade. Likewise, bundle export/import lives in the [Action API v2](bundles.md), not in this server.
+This server now bundles a small **API v2 (beta)** layer (prompt-an-agent `promptAgent`, agent-chat, webhook subscribe/unsubscribe) on top of the v1 surface. Note: bundle export/import still lives in the [Action API v2](bundles.md), not in this server.
 {% endhint %}
 
 For the full tool list, see the [Workspace MCP](workspace-mcp.md) reference.

--- a/apis-living-system-development/workspace-mcp-advanced.md
+++ b/apis-living-system-development/workspace-mcp-advanced.md
@@ -197,7 +197,7 @@ Plan features may evolve. Check the [pricing page](https://www.taskade.com/prici
 
 ## Tool Catalog Details
 
-The inbound server exposes **62 tools** across 8 categories whose names mirror the [REST API v1](comprehensive-api-guide/README.md) operations it wraps, plus a small **Agent Chat & Webhooks (API v2, beta)** group (`promptAgent`, `listConversations`, `getConversation`, `subscribeWebhook`, `unsubscribeWebhook`). Below are the ones integrators most often need to configure precisely.
+The inbound server exposes **62 tools** across 8 categories. Most mirror the [REST API v1](comprehensive-api-guide/README.md) operations it wraps; the newest category is a small **Agent Chat & Webhooks (API v2, beta)** group (`promptAgent`, `listConversations`, `getConversation`, `subscribeWebhook`, `unsubscribeWebhook`). Below are the ones integrators most often need to configure precisely.
 
 ### `projectTasksGet`
 

--- a/apis-living-system-development/workspace-mcp.md
+++ b/apis-living-system-development/workspace-mcp.md
@@ -93,7 +93,7 @@ HTTP mode accepts the token as a query parameter (`?access_token=…`). Only use
 
 ## Available Tools
 
-The server exposes **57 tools** across 7 categories. Tool names mirror the [REST API v1](comprehensive-api-guide/README.md) operations the server wraps:
+The server exposes **62 tools** across 8 categories. Tool names mirror the [REST API v1](comprehensive-api-guide/README.md) operations the server wraps:
 
 | Area | Tools |
 | --- | --- |
@@ -104,9 +104,10 @@ The server exposes **57 tools** across 7 categories. Tool names mirror the [REST
 | **Agents** | `folderAgentGenerate`, `folderCreateAgent`, `folderAgentGet`, `agentGet`, `agentUpdate`, `deleteAgent`, `agentKnowledgeProjectCreate`, `agentKnowledgeMediaCreate`, `agentKnowledgeProjectRemove`, `agentKnowledgeMediaRemove`, `agentPublicAccessEnable`, `agentPublicGet`, `agentPublicUpdate`, `agentConvosGet`, `agentConvoGet`, `publicAgentGet` |
 | **Media** | `mediasGet`, `mediaGet`, `mediaDelete` |
 | **Personal** | `meProjectsGet` |
+| **Agent Chat & Webhooks (API v2, beta)** | `promptAgent`, `listConversations`, `getConversation`, `subscribeWebhook`, `unsubscribeWebhook` |
 
 {% hint style="info" %}
-This local server wraps **v1**, so it does **not** include a prompt-an-agent tool. To prompt agents programmatically, use [`POST /api/v2/promptAgent`](api-v2-reference.md#prompt-an-agent), or chat with the agent inside Taskade.
+As of v0.1.1 this server also bundles a small **API v2 (beta)** layer — including a **prompt-an-agent** tool (`promptAgent`), agent-chat (`listConversations`, `getConversation`), and webhook subscribe/unsubscribe (`subscribeWebhook`, `unsubscribeWebhook`). The rest of the surface mirrors [REST API v1](comprehensive-api-guide/README.md).
 {% endhint %}
 
 ## Example Usage in Claude


### PR DESCRIPTION
## Summary

The Workspace MCP docs still advertise **57 tools across 7 categories** and assert the server "wraps v1 … does not include a prompt-an-agent tool." Both are stale: `@taskade/mcp-server@0.1.1` ships **62 tools (57 v1 + 5 v2)**, including a prompt-an-agent tool. This PR makes the docs match the shipped server.

## What changed

| File | Before | After | Why |
|------|--------|-------|-----|
| `workspace-mcp.md` | "57 tools across 7 categories" | "62 tools across 8 categories" | Reflects the shipped v2 layer |
| `workspace-mcp.md` | tool list missing v2 tools | adds **Agent Chat & Webhooks (API v2, beta)**: `promptAgent`, `listConversations`, `getConversation`, `subscribeWebhook`, `unsubscribeWebhook` | The 5 net-new capabilities |
| `workspace-mcp.md` | hint: "wraps v1 … no prompt-an-agent tool" | accurate v2-beta note | The claim is now false |
| `workspace-mcp-advanced.md` | "57 tools across 7 categories" | "62 tools across 8 categories" | Same drift |
| `workspace-mcp-advanced.md` | hint: "no prompt-an-agent tool" + bundle note | drops false prompt-agent claim, **keeps** the (still-true) bundle-export-not-included note | Surgical correctness |

## Why it matters

A non-technical operator reads the docs, is told a capability doesn't exist, and never asks their assistant to chat with their agent — even though the server they installed supports it. Docs that contradict the shipped binary are the worst kind of consistency failure.

## Verification / zero-regression

- Ground truth: `57 v1` (`packages/server/src/constants.ts`) + `5 v2` (`constants.v2.ts`), both registered in `server.ts` on `origin/main`.
- Minimal edits; GitBook `{% hint %}` blocks and the `bundles.md` link preserved; no v1 tools removed.

## Merge order

Touches `workspace-mcp.md`, also edited by **D5** (adds a banner) and **D7** (reorders + collapses catalog). Merge **D1 → D5 → D7** to minimize rebasing.

---
Part of the docs-led dual-repo MCP roadmap. Verified baseline: 0.1.1 · 62 tools (57 v1 + 5 v2) · canonical endpoint `https://www.taskade.com/mcp` · token `https://www.taskade.com/settings/api`.

🤖 Authored with Claude Code (multi-agent verified)
