### PR TITLE
docs(mcp): normalize hosted endpoint to canonical https://www.taskade.com/mcp

### DIFF
--- a/apis-living-system-development/developer-home.md
+++ b/apis-living-system-development/developer-home.md
@@ -18,7 +18,7 @@ graph TB
         API1[REST API v1<br/>RESTful + OAuth 2.0]
         API2[Action API v2<br/>RPC + OAuth 2.0]
         MCP_IN["@taskade/mcp-server<br/>Inbound MCP, npm"]
-        MCP_HOST[Hosted MCP<br/>taskade.com/mcp]
+        MCP_HOST[Hosted MCP<br/>https://www.taskade.com/mcp]
         MCP_OUT[MCP Connectors<br/>Outbound to 31+ services]
         WEBHOOK[Webhooks<br/>Automation triggers]
     end
@@ -87,7 +87,7 @@ Treat your API token like a password. Never commit it to version control or shar
 | [Authentication Guide](developers/authentication.md) | Personal access tokens and OAuth 2.0 (PKCE) flows |
 | [Workspace MCP](workspace-mcp.md) | Run `@taskade/mcp-server` to connect Claude Desktop, Cursor, and Claude Code ([source](https://github.com/taskade/mcp)) |
 | [Workspace MCP — Advanced](workspace-mcp-advanced.md) | Multi-client setup, troubleshooting, security |
-| [Hosted MCP — Genesis App (Beta)](genesis-app-mcp.md) | Edit your Genesis app's source from your IDE via the remote `taskade.com/mcp` server |
+| [Hosted MCP — Genesis App (Beta)](genesis-app-mcp.md) | Edit your Genesis app's source from your IDE via the remote `https://www.taskade.com/mcp` server |
 | [MCP Connectors](../genesis-living-system-builder/genesis/mcp-connectors.md) | Give Taskade agents 31+ third-party tools (outbound MCP) |
 | [Integration Kit (GitHub)](https://github.com/taskade/integrations) | Open-source Zapier and n8n actions & triggers built on the public API — contribute or self-host |
 | [Webhooks](webhooks.md) | Trigger automations from external events; call out to any API |

--- a/apis-living-system-development/developers/authentication.md
+++ b/apis-living-system-development/developers/authentication.md
@@ -14,7 +14,7 @@ Every Taskade developer surface — the [REST API v1](../comprehensive-api-guide
 | --- | --- | --- |
 | Writing a script, or using the SDK / CLI / inbound `@taskade/mcp-server` | **Personal Access Token** | `Authorization: Bearer tskdp_…` |
 | Building a third-party app that acts on behalf of other users | **OAuth 2.0** (Authorization Code + PKCE) | Redirect flow |
-| Connecting Claude / Cursor to the **hosted** MCP at `taskade.com/mcp` | **OAuth 2.0** | Handled automatically by the MCP client |
+| Connecting Claude / Cursor to the **hosted** MCP at `https://www.taskade.com/mcp` | **OAuth 2.0** | Handled automatically by the MCP client |
 
 ---
 
@@ -135,7 +135,7 @@ Only `authorization_code` and `refresh_token` grants are supported. `password`, 
 
 ### Scopes & the hosted MCP
 
-The hosted MCP server at [taskade.com/mcp](../genesis-app-mcp.md) requires an OAuth token carrying the **`mcp`** scope. MCP clients (Claude Desktop, Cursor, Claude Code) perform this OAuth handshake — including dynamic client registration — automatically when you add the server URL, so you normally don't implement it yourself.
+The hosted MCP server at [https://www.taskade.com/mcp](../genesis-app-mcp.md) requires an OAuth token carrying the **`mcp`** scope. MCP clients (Claude Desktop, Cursor, Claude Code) perform this OAuth handshake — including dynamic client registration — automatically when you add the server URL, so you normally don't implement it yourself.
 
 ---
 

--- a/apis-living-system-development/genesis-app-mcp.md
+++ b/apis-living-system-development/genesis-app-mcp.md
@@ -1,7 +1,7 @@
 ---
 description: >-
   Connect Claude, Cursor, or any MCP client to your Taskade Genesis app's source
-  code via the hosted taskade.com/mcp server (OAuth 2.0, Business plan).
+  code via the hosted https://www.taskade.com/mcp server (OAuth 2.0, Business plan).
 ---
 
 # Genesis App MCP (Beta)
@@ -15,7 +15,7 @@ Taskade has three MCP surfaces. This page covers the **hosted Taskade Genesis Ap
 | Surface | Transport | Auth | Touches | Plan |
 | --- | --- | --- | --- | --- |
 | [Workspace MCP](workspace-mcp.md) (`@taskade/mcp-server`) | Local stdio (you run it) | Personal token | Workspace **content** (projects, tasks, agents) | Most plans |
-| **Hosted Genesis App MCP** (this page) | Hosted HTTP (`taskade.com/mcp`) | OAuth 2.0 | Genesis app **source code** | Business+ |
+| **Hosted Genesis App MCP** (this page) | Hosted HTTP (`https://www.taskade.com/mcp`) | OAuth 2.0 | Genesis app **source code** | Business+ |
 | [MCP Connectors](../genesis-living-system-builder/genesis/mcp-connectors.md) | Hosted (outbound) | Per-connector | **Third-party** services from your agents | Varies |
 
 Genesis App MCP lets you connect your favorite AI tools — Claude Desktop, Claude Code, Cursor, or any MCP-compatible client — directly to your Taskade Genesis app's **source code**. Browse your workspace from your IDE, and edit your app's React components, styles, and configuration using the model and workflow you already love.


### PR DESCRIPTION
## Summary

The hosted Genesis App MCP endpoint appears as bare `taskade.com/mcp` (no scheme, no `www`) in prose, YAML, a decision-table cell, and the developer-home mermaid diagram. The canonical form is `https://www.taskade.com/mcp` (per repo issue #37). A copied bare string can hit a redirect or fail; one consistent surface form reads as trustworthy. Config JSON blocks already use the canonical form and are left untouched.

## What changed

| File | Location | Before | After |
|------|----------|--------|-------|
| `genesis-app-mcp.md` | YAML `description` | `taskade.com/mcp` | `https://www.taskade.com/mcp` |
| `genesis-app-mcp.md` | "Which MCP" table cell | `taskade.com/mcp` | `https://www.taskade.com/mcp` |
| `developer-home.md` | mermaid node label | `taskade.com/mcp` | `https://www.taskade.com/mcp` |
| `developer-home.md` | Resources table | `taskade.com/mcp` | `https://www.taskade.com/mcp` |
| `developers/authentication.md` | "Which auth?" table | `taskade.com/mcp` | `https://www.taskade.com/mcp` |
| `developers/authentication.md` | Scopes prose link text | `taskade.com/mcp` | `https://www.taskade.com/mcp` |

## Verification / zero-regression

- Config JSON endpoint blocks left untouched (already canonical).
- Relative link targets (e.g. `../genesis-app-mcp.md`) unchanged — only display text/host strings normalized.
- `/settings/...` URLs untouched (owned by PR D2).

## Merge order

Soft overlaps (different lines, auto-mergeable): `authentication.md` with **D2**; `developer-home.md` with **D4**; the `genesis-app-mcp.md` table cell with **D5** (which relocates that table and writes the canonical endpoint there — so the result is correct regardless of merge order).

---
Canonical endpoint: `https://www.taskade.com/mcp` (#37).

🤖 Authored with Claude Code (multi-agent verified)
