### PR TITLE
docs(mcp): fix cross-surface mislink — third-party capabilities -> MCP Connectors page

### DIFF
--- a/apis-living-system-development/developer-home.md
+++ b/apis-living-system-development/developer-home.md
@@ -58,7 +58,7 @@ graph TB
 | Prompt agents, manage agents, export/import bundles | [Action API v2](api-v2-reference.md) |
 | Hit endpoints from any language | [REST API v1](comprehensive-api-guide/README.md) + [Action API v2](api-v2-reference.md) |
 | Expose Taskade data to Claude Desktop, Cursor, or other MCP clients | [Workspace MCP](workspace-mcp.md) + [Advanced](workspace-mcp-advanced.md) |
-| Give a Taskade agent third-party capabilities | [MCP Connectors](workspace-mcp-advanced.md#mcp-connectors) |
+| Give a Taskade agent third-party capabilities | [MCP Connectors](../genesis-living-system-builder/genesis/mcp-connectors.md) |
 | Edit Taskade Genesis app source code from your IDE | [Hosted MCP (Genesis App)](genesis-app-mcp.md) |
 | Receive real-time events in your app | [Webhooks](webhooks.md) |
 | Understand long-term memory | [Long-Term Memory](long-term-memory.md) |


### PR DESCRIPTION
## Summary

In `developer-home.md`'s "I Want To…" table, "Give a Taskade agent third-party capabilities" links to `workspace-mcp-advanced.md#mcp-connectors` — a subsection of the **Workspace MCP** doc. But MCP **Connectors** is a distinct surface with its own canonical page. This sends an operator to the wrong surface. The same file already links the correct Connectors page elsewhere (line ~91); this removes the internal inconsistency.

## What changed

| File | Before | After |
|------|--------|-------|
| `developer-home.md` ("I Want To…" table) | `[MCP Connectors](workspace-mcp-advanced.md#mcp-connectors)` | `[MCP Connectors](../genesis-living-system-builder/genesis/mcp-connectors.md)` |

## Why it matters

The three MCP surfaces (Workspace MCP / Genesis App MCP / MCP Connectors) must never blur. A mislink here routes the "connect my other tools" intent into the wrong server's docs.

## Scope note

Connector-count reconciliation was considered and **cut**: the relevant files do not actually disagree, and the "100+" figure elsewhere refers to *automation integrations* (a separate concept). No count was touched.

## Merge order

Touches `developer-home.md`, also edited by **D3** (a different line — endpoint string). Auto-mergeable.

---
🤖 Authored with Claude Code (multi-agent verified)
