### PR TITLE
docs(mcp): outcome-first MCP Overview decision page + read-only hand-off + cross-surface banners

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -164,7 +164,7 @@
 * [Action API v2 Reference](apis-living-system-development/api-v2-reference.md)
 * [TypeScript SDK (Preview)](apis-living-system-development/sdk-quickstart.md)
   * [SDK Cookbook](apis-living-system-development/sdk-cookbook.md)
-* [Which MCP do I want?](apis-living-system-development/mcp-overview.md)
+* [Which Taskade MCP do I want?](apis-living-system-development/mcp-overview.md)
 * [Workspace MCP](apis-living-system-development/workspace-mcp.md)
   * [Workspace MCP: Advanced](apis-living-system-development/workspace-mcp-advanced.md)
   * [Hosted MCP — Genesis App (Beta)](apis-living-system-development/genesis-app-mcp.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -164,6 +164,7 @@
 * [Action API v2 Reference](apis-living-system-development/api-v2-reference.md)
 * [TypeScript SDK (Preview)](apis-living-system-development/sdk-quickstart.md)
   * [SDK Cookbook](apis-living-system-development/sdk-cookbook.md)
+* [Which MCP do I want?](apis-living-system-development/mcp-overview.md)
 * [Workspace MCP](apis-living-system-development/workspace-mcp.md)
   * [Workspace MCP: Advanced](apis-living-system-development/workspace-mcp-advanced.md)
   * [Hosted MCP — Genesis App (Beta)](apis-living-system-development/genesis-app-mcp.md)

--- a/apis-living-system-development/genesis-app-mcp.md
+++ b/apis-living-system-development/genesis-app-mcp.md
@@ -10,13 +10,7 @@ description: >-
 
 ## Which MCP do I want?
 
-Taskade has three MCP surfaces. This page covers the **hosted Taskade Genesis App MCP**.
-
-| Surface | Transport | Auth | Touches | Plan |
-| --- | --- | --- | --- | --- |
-| [Workspace MCP](workspace-mcp.md) (`@taskade/mcp-server`) | Local stdio (you run it) | Personal token | Workspace **content** (projects, tasks, agents) | Most plans |
-| **Hosted Genesis App MCP** (this page) | Hosted HTTP (`https://www.taskade.com/mcp`) | OAuth 2.0 | Genesis app **source code** | Business+ |
-| [MCP Connectors](../genesis-living-system-builder/genesis/mcp-connectors.md) | Hosted (outbound) | Per-connector | **Third-party** services from your agents | Varies |
+> See **[Which Taskade MCP do I want?](mcp-overview.md)** for the full three-surface comparison. This page covers the **hosted Genesis App MCP**.
 
 Genesis App MCP lets you connect your favorite AI tools — Claude Desktop, Claude Code, Cursor, or any MCP-compatible client — directly to your Taskade Genesis app's **source code**. Browse your workspace from your IDE, and edit your app's React components, styles, and configuration using the model and workflow you already love.
 

--- a/apis-living-system-development/mcp-overview.md
+++ b/apis-living-system-development/mcp-overview.md
@@ -1,0 +1,17 @@
+---
+description: >-
+  Three Taskade MCP surfaces, one decision. Pick the right one by what you want
+  to do.
+---
+
+# Which Taskade MCP do I want?
+
+Taskade speaks MCP (Model Context Protocol) through **three** surfaces. Pick by what you want to do — the transport and auth details are secondary.
+
+| I want to… | Use | Where / auth |
+|---|---|---|
+| Have Claude **read & change my projects, tasks, and agents** | **[Workspace MCP](workspace-mcp.md)** (`@taskade/mcp-server`) | Local stdio · personal token (`https://www.taskade.com/settings/api`) · most plans |
+| **Edit my published app's design & code** from my IDE | **[Genesis App MCP](genesis-app-mcp.md)** | Hosted · OAuth 2.0 (`https://www.taskade.com/mcp`) · Business+ |
+| Let my agents **reach Slack, Shopify, Gmail** & other tools | **[MCP Connectors](../genesis-living-system-builder/genesis/mcp-connectors.md)** | Hosted, in-product |
+
+> **Heads up:** Genesis App MCP edits your app's *code* — your projects, tasks, and agents stay **read-only** there. To read and change that content, use **[Workspace MCP](workspace-mcp.md)**.

--- a/apis-living-system-development/workspace-mcp.md
+++ b/apis-living-system-development/workspace-mcp.md
@@ -8,6 +8,8 @@ description: >-
 
 > **Editing Taskade Genesis app source code instead?** See [Hosted MCP — Genesis App (Beta)](genesis-app-mcp.md) for the remote server that writes to your app's source files.
 
+> **Not sure which Taskade MCP you need?** See [Which Taskade MCP do I want?](mcp-overview.md).
+
 Workspace MCP connects [Claude Desktop](https://claude.ai), [Cursor](https://cursor.sh), [Claude Code](https://claude.com/claude-code), [Windsurf](https://codeium.com/windsurf), [VS Code](https://code.visualstudio.com/), or any MCP-compatible AI tool to your Taskade **workspace content** — workspaces, projects, tasks, agents, and media. It's a small server you run locally that wraps the [REST API v1](comprehensive-api-guide/README.md), so it has full task read/write access.
 
 ## What is MCP?

--- a/genesis-living-system-builder/genesis/mcp-connectors.md
+++ b/genesis-living-system-builder/genesis/mcp-connectors.md
@@ -6,6 +6,8 @@ description: >-
 
 # MCP Connectors
 
+> **Not sure which Taskade MCP you need?** See [Which Taskade MCP do I want?](../../apis-living-system-development/mcp-overview.md).
+
 ## What is MCP?
 
 **Model Context Protocol (MCP)** is an open standard that lets AI agents connect to external tools and services. Think of it as **USB-C for AI** — one universal, standardized, vendor-agnostic protocol that works across platforms and providers.


### PR DESCRIPTION
## Summary

The "Which MCP do I want?" disambiguator lives *inside* `genesis-app-mcp.md` — the very page an operator can't choose to open until they already know which surface they need. This PR promotes it to a standalone, **outcome-first** decision page (`mcp-overview.md`), reframes the first column as the operator's job-to-be-done, adds the positive read-only hand-off line, and links to it from the other surfaces.

## What changed

| File | Change | Why |
|------|--------|-----|
| `mcp-overview.md` (new) | Standalone "Which Taskade MCP do I want?" page — outcome-first table + read-only hand-off line | One obvious door routes the operator in under a minute |
| `genesis-app-mcp.md` | Relocated table → pointer to the overview (heading kept) | Single source of truth for the decision |
| `workspace-mcp.md` | Top banner → overview | Cross-surface discoverability |
| `mcp-connectors.md` | Top banner → overview (had zero cross-surface refs) | Connects the third surface |
| `SUMMARY.md` | One new nav entry for the overview | Reachable by browsing |

## Why it matters (the David cohort)

A non-technical operator thinks in outcomes ("have Claude change my projects," "let my agents reach Shopify"), not in PATs vs OAuth vs stdio. The read-only boundary on Genesis App MCP is the #1 disappointment trap; phrasing it as "for those, use Workspace MCP" turns a wall into a confident hand-off.

## Design lens

Atkinson (one obvious door; smallest visible win = find your row) + Mead (each row is a capability you command) + Geist (nav mirrors the decision).

## Verification / zero-regression

- All three table targets and both banner targets verified to exist; relative paths checked.
- `SUMMARY.md` lines 167–170 (Workspace → Advanced → Genesis App → Connectors) left intact — only one entry added.
- New table uses the canonical `https://www.taskade.com/mcp` endpoint, so it is correct regardless of merge order with **D3**.

## Merge order

`workspace-mcp.md` is also touched by **D1** (tool count) and **D7** (reorder) — merge **D1 → D5 → D7**. `genesis-app-mcp.md` table region overlaps **D3** (endpoint string) — trivially resolvable. `SUMMARY.md` also gets one entry from **D8** (different line).

---
Part of the docs-led dual-repo MCP roadmap. Canonical endpoint `https://www.taskade.com/mcp`; token `https://www.taskade.com/settings/api`.

🤖 Authored with Claude Code (multi-agent verified)
