### PR TITLE
docs(mcp): lead Workspace MCP with what you can do; demote tool catalog to a reference section

### DIFF
--- a/apis-living-system-development/workspace-mcp.md
+++ b/apis-living-system-development/workspace-mcp.md
@@ -93,7 +93,22 @@ The server listens on `http://localhost:3000` (set `PORT` to change it); connect
 HTTP mode accepts the token as a query parameter (`?access_token=…`). Only use this on a trusted local network or behind TLS — never expose it publicly.
 {% endhint %}
 
-## Available Tools
+## Example Usage in Claude
+
+Once configured, you can run your workspace by talking. Ask Claude to:
+
+- "Spin up next week's client-onboarding tasks and assign them."
+- "Mark every overdue invoice task complete and tell me what's left."
+- "Create a project for the Q3 launch with a task per milestone."
+- "Summarize what changed in my Marketing space this week."
+- "List all my Taskade workspaces"
+- "Create a task in my Sales Pipeline project to follow up with the client"
+- "Show me the tasks in my Sales Pipeline project and mark the first one complete"
+- "Add a due date of next Friday to task X"
+
+## Full tool reference
+
+Every tool the server exposes, grouped by category — reach for this when you want to wire something precisely.
 
 The server exposes **62 tools** across 8 categories. Tool names mirror the [REST API v1](comprehensive-api-guide/README.md) operations the server wraps:
 
@@ -111,15 +126,6 @@ The server exposes **62 tools** across 8 categories. Tool names mirror the [REST
 {% hint style="info" %}
 As of v0.1.1 this server also bundles a small **API v2 (beta)** layer — including a **prompt-an-agent** tool (`promptAgent`), agent-chat (`listConversations`, `getConversation`), and webhook subscribe/unsubscribe (`subscribeWebhook`, `unsubscribeWebhook`). The rest of the surface mirrors [REST API v1](comprehensive-api-guide/README.md).
 {% endhint %}
-
-## Example Usage in Claude
-
-Once configured, you can ask Claude to:
-
-- "List all my Taskade workspaces"
-- "Create a task in my Sales Pipeline project to follow up with the client"
-- "Show me the tasks in my Sales Pipeline project and mark the first one complete"
-- "Add a due date of next Friday to task X"
 
 ## Plan Availability
 


### PR DESCRIPTION
## Summary

The Workspace MCP page opens with a wall of camelCase tool names (`taskFieldValueDelete` …) — which reads as homework to a non-technical operator. This PR reorders the page to lead with **what you can do** (business-outcome prompts and example usage) and demotes the full tool list to a clearly-labeled reference section. No content is removed — only reordered.

## What changed

| Section | Before | After |
|---------|--------|-------|
| Example Usage / business prompts | below the tool catalog | **moved to the top**, with 3–4 concrete business prompts |
| Full tool catalog (camelCase) | top of page | **demoted** to "Full tool reference" lower down |

## Why it matters (the David cohort)

An operator should feel "I can run my business by talking" before being asked to read 60 API verb names. Lead with the outcome; keep the catalog as the precise reference it is.

## Design lens

Atkinson + Mead — lead with the capability the reader commands; the API surface is reference, not the headline.

## Verification / zero-regression

- Pure reorder + reheading: the set of tool names and links is unchanged (verified by diffing the tool set).
- Tool **count** text and the agent-chat `{% hint %}` are intentionally untouched — owned by **D1**.

## Merge order

`workspace-mcp.md` is also edited by **D1** (count/hint) and **D5** (top banner). This PR reorders large blocks, so merge it **last**: D1 → D5 → **D7** (rebase D7 on the others).

---
🤖 Authored with Claude Code (multi-agent verified)
