### PR TITLE
docs(mcp): new operator guide — run your live Genesis app by talking to Claude

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -166,6 +166,7 @@
   * [SDK Cookbook](apis-living-system-development/sdk-cookbook.md)
 * [Which Taskade MCP do I want?](apis-living-system-development/mcp-overview.md)
 * [Workspace MCP](apis-living-system-development/workspace-mcp.md)
+  * [Run your live app by talking to Claude](apis-living-system-development/run-your-app-with-ai.md)
   * [Workspace MCP: Advanced](apis-living-system-development/workspace-mcp-advanced.md)
   * [Hosted MCP — Genesis App (Beta)](apis-living-system-development/genesis-app-mcp.md)
 * [MCP Connectors](genesis-living-system-builder/genesis/mcp-connectors.md)

--- a/apis-living-system-development/run-your-app-with-ai.md
+++ b/apis-living-system-development/run-your-app-with-ai.md
@@ -1,0 +1,56 @@
+---
+description: >-
+  Once your Genesis app is live, run its day-to-day data by talking to Claude —
+  no IDs, no API code.
+---
+
+# Run your live app by talking to Claude
+
+You built your business app with Genesis. Now operate it in plain English: read your records, update fields, mark work done, and flag what needs attention — by talking to Claude (or any AI client) through **[Workspace MCP](workspace-mcp.md)**.
+
+## What you'll need
+
+- **[Workspace MCP](workspace-mcp.md)** connected to your AI client (one-time setup).
+- Your Taskade personal token from [https://www.taskade.com/settings/api](https://www.taskade.com/settings/api).
+- The link to your Genesis app (the project it's built on).
+
+## 1. Point your assistant at your app
+
+You don't need to copy any ID out of a URL. Paste your app's link and ask:
+
+> "Here's my app: <paste link>. Find this project and show me what's inside."
+
+Your assistant resolves the project for you and lists its contents.
+
+## 2. Read your business
+
+> "Show me every overdue job."
+>
+> "What's the status of the Johnson project?"
+>
+> "List this week's new client intakes."
+
+## 3. Update records and fields
+
+> "Mark the Johnson job complete and set the next service date to next Friday."
+>
+> "Log this invoice against the Acme account."
+>
+> "Add a 'priority' field to overdue tasks and set it to High."
+
+## 4. Let it keep watch
+
+> "Flag anything overdue and tell me what needs my attention today."
+
+## What this changes — and what it doesn't
+
+This guide uses **Workspace MCP**, which reads and writes your app's **content** — the projects, tasks, fields, and records your business runs on.
+
+{% hint style="info" %}
+It does **not** edit your app's deployed design or layout. To change your app's pages, components, or styles, use the Genesis builder or **[Genesis App MCP](genesis-app-mcp.md)** — which edits your app's *code* and keeps content read-only.
+{% endhint %}
+
+## Next steps
+
+- New to MCP? Start with **[Workspace MCP](workspace-mcp.md)**.
+- Want your agents to reach Slack, Shopify, or Gmail? See **[MCP Connectors](../genesis-living-system-builder/genesis/mcp-connectors.md)**.

--- a/genesis-living-system-builder/run-your-business/README.md
+++ b/genesis-living-system-builder/run-your-business/README.md
@@ -69,4 +69,5 @@ Run the checklist, right-size your plan and credits, and launch. → [Go-live ch
 * [From idea to live business — the 5 steps](from-idea-to-live-business.md)
 * [Build a client or member portal](build-a-client-portal.md)
 * [Build an internal ops dashboard](build-an-ops-dashboard.md)
+* **Operate your live app by talking to Claude** — read and update your app's data in plain English. See [Run your live app by talking to Claude](../../apis-living-system-development/run-your-app-with-ai.md).
 * [What your app will cost](../../account-management/credits-and-billing.md)

--- a/genesis-living-system-builder/run-your-business/from-idea-to-live-business.md
+++ b/genesis-living-system-builder/run-your-business/from-idea-to-live-business.md
@@ -63,3 +63,4 @@ Your app runs on AI, and AI runs on credits. Before launch, match your plan and 
 * [Add Login & Roles](./add-login-and-roles.md) — go deeper on accounts and access control
 * [Getting Started with Taskade Genesis](../genesis/getting-started.md) — revisit Step 1 to refine your app
 * [Custom Domains & Branding](../space-apps-guide/custom-domains.md) — polish your branded launch
+* [Run your live app by talking to Claude](../../apis-living-system-development/run-your-app-with-ai.md) — once you're live, read and update your app's data in plain English


### PR DESCRIPTION
## Summary

An operator finishes the 5-step "run your business" build track and is never told the highest-value thing they can now do: **operate their live app's data by talking to Claude**. This adds a net-new, outcome-first guide (no IDs, no API code) and links it from the run-your-business track and nav.

## What changed

| File | Change |
|------|--------|
| `run-your-app-with-ai.md` (new) | Outcome-first guide: point at your app → read → update records/fields → flag overdue; honest content-vs-code boundary |
| `SUMMARY.md` | Nav entry under Workspace MCP |
| `run-your-business/README.md` | Outcome-framed pointer to the new guide |
| `run-your-business/from-idea-to-live-business.md` | One-line pointer at the end |

## Why it matters (the David cohort)

This is the single highest impact-per-effort operator outcome: "I run my live business by talking — mark the Johnson job done, log the invoice, flag overdue — no engineer." The guide leads with the edited record and resolves IDs for the user rather than asking them to copy hashes from URLs.

## Design lens

Mead — "your back-office answers to you in plain English." Atkinson — bury the ID step; lead with the outcome.

## Verification / zero-regression

- Capability verified: Workspace MCP reads & writes workspace content (the app's data). The guide states the honest boundary (it does NOT edit the deployed UI — that's the Genesis builder / Genesis App MCP).
- All links target pages that exist on `main`; additive only.

## Merge order

`run-your-business/README.md` also gets a pointer from **D9** (different location). `SUMMARY.md` also gets one entry from **D5**. Both auto-mergeable.

---
🤖 Authored with Claude Code (multi-agent verified)
