### PR TITLE
docs(mcp): make MCP Connectors reachable — inline links from automation & run-your-business

### DIFF
--- a/genesis-living-system-builder/automation/README.md
+++ b/genesis-living-system-builder/automation/README.md
@@ -139,6 +139,7 @@ Connect your workflows to popular tools across the [Taskade integrations](https:
 * Step catalog: [Actions & Triggers](actions.md)
 * Pick tools to connect: [Integration Overview](comprehensive-integration-guide.md)
 * Full list of connectors: [Integration Options](integrations.md)
+* **Let your agents reach external tools** (Slack, Stripe, Shopify, Gmail) via [MCP Connectors](../genesis/mcp-connectors.md).
 * Troubleshoot: [Living System Troubleshooting](../community-and-sharing/troubleshooting.md)
 
 ## Next steps

--- a/genesis-living-system-builder/genesis/how-genesis-works.md
+++ b/genesis-living-system-builder/genesis/how-genesis-works.md
@@ -202,6 +202,8 @@ Execution means **intelligent automation workflows** — the nervous system that
 
 > **Deep dive:** [Automations: The Execution Pillar](../automation/README.md)
 
+Connect your agents to Slack, Stripe, Shopify, and more with [MCP Connectors](mcp-connectors.md).
+
 ---
 
 ## The Self-Reinforcing Feedback Loop

--- a/genesis-living-system-builder/run-your-business/README.md
+++ b/genesis-living-system-builder/run-your-business/README.md
@@ -71,3 +71,4 @@ Run the checklist, right-size your plan and credits, and launch. → [Go-live ch
 * [Build an internal ops dashboard](build-an-ops-dashboard.md)
 * **Operate your live app by talking to Claude** — read and update your app's data in plain English. See [Run your live app by talking to Claude](../../apis-living-system-development/run-your-app-with-ai.md).
 * [What your app will cost](../../account-management/credits-and-billing.md)
+* **Extend your live system:** read & write your data with [Workspace MCP](../../apis-living-system-development/workspace-mcp.md), edit your app's code with [Genesis App MCP](../../apis-living-system-development/genesis-app-mcp.md), or connect external tools with [MCP Connectors](../genesis/mcp-connectors.md).


### PR DESCRIPTION
## Summary

The MCP Connectors catalog — the exact "connect my other tools" outcome — is fully documented but unreachable by browsing from the automation pages that promise integrations. This PR adds outcome-framed inline links from those pages (and a "what you can extend" pointer from the run-your-business track) into the connectors page.

## What changed

| File | Change |
|------|--------|
| `automation/README.md` | Added: "let your agents reach external tools (Slack/Stripe/Shopify/Gmail) → MCP Connectors" (existing `integrations.md` links kept) |
| `genesis/how-genesis-works.md` | One-line outcome pointer to MCP Connectors |
| `run-your-business/README.md` | "Extend your live system" pointer into all three MCP surfaces |

## Why it matters (the David cohort)

An operator reading about automations never learns connectors are how agents reach those tools. This wires the intent to the catalog.

## Scope notes

- MCP **Connectors** ≠ automation **Integration Options** (`integrations.md`) — these are distinct concepts; existing integrations links are preserved, not replaced.
- No count number introduced or changed (the "orphan / add-to-SUMMARY" clause was cut — MCP Connectors is already in `SUMMARY.md`).

## Merge order

`run-your-business/README.md` also gets a pointer from **D8** (different location). Auto-mergeable.

---
🤖 Authored with Claude Code (multi-agent verified)
