### PR TITLE
docs: developer changelog catch-up (Jun 24–Jul 1) + devex polish

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -179,7 +179,12 @@
 
 * [Upcoming Changes](updates-and-timeline/upcoming-changes.md)
 * [Changelog (2026)](updates-and-timeline/changelog-2026/README.md)
+  * [July 2026](updates-and-timeline/changelog-2026/july-2026/README.md)
+    * [July 1, 2026](updates-and-timeline/changelog-2026/july-2026/july-1-2026.md)
   * [June 2026](updates-and-timeline/changelog-2026/june-2026/README.md)
+    * [June 30, 2026](updates-and-timeline/changelog-2026/june-2026/june-30-2026.md)
+    * [June 29, 2026](updates-and-timeline/changelog-2026/june-2026/june-29-2026.md)
+    * [June 28, 2026](updates-and-timeline/changelog-2026/june-2026/june-28-2026.md)
     * [June 23, 2026](updates-and-timeline/changelog-2026/june-2026/june-23-2026.md)
     * [June 22, 2026](updates-and-timeline/changelog-2026/june-2026/june-22-2026.md)
     * [June 19, 2026](updates-and-timeline/changelog-2026/june-2026/june-19-2026.md)

--- a/genesis-living-system-builder/ai-features/ai-agents-getting-started.md
+++ b/genesis-living-system-builder/ai-features/ai-agents-getting-started.md
@@ -192,21 +192,18 @@ Make your agent smart by giving it information:
 
 ### Step 4.5: Choose Your AI Model
 
-Select the right AI model based on your needs:
+Select the right AI model based on your needs. Taskade's model picker offers current frontier models from multiple providers — including the Claude, GPT, and Gemini families — and the lineup is refreshed as new models ship (see the [changelog](../../updates-and-timeline/changelog-2026/README.md) for additions):
 
-| Model                       | Speed     | Complexity Handling | Best For                                      |
-| --------------------------- | --------- | ------------------- | --------------------------------------------- |
-| **Pro (GPT-4o)**            | Medium    | ⭐⭐⭐⭐⭐               | Deep reasoning, accurate data analysis        |
-| **Standard (GPT-4o mini)**  | Fast      | ⭐⭐⭐⭐☆               | Balanced performance, good context handling   |
-| **Pro (GPT-4.1)**           | Medium    | ⭐⭐⭐⭐⭐               | High-end reasoning, coding, and task planning |
-| **Standard (GPT-4.1 mini)** | Fast      | ⭐⭐⭐⭐⭐               | Complex workflows with fast responses         |
-| **Basic (GPT-4.1 nano)**    | Very Fast | ⭐⭐⭐☆☆               | Lightweight LLM usage, quick queries          |
-| **Advanced (o4-mini)**      | Fast      | ⭐⭐⭐⭐☆               | Fast processing for moderately complex tasks  |
-| **Standard (o4-mini)**      | Very Fast | ⭐⭐⭐☆☆               | Speed-priority tasks with decent reasoning    |
-| **Basic (o4-mini)**         | Fastest   | ⭐⭐☆☆☆               | Ultra-fast, low-load tasks                    |
-| **Advanced (o3-mini)**      | Fast      | ⭐⭐⭐⭐☆               | Data-heavy tasks                              |
-| **Standard (o3-mini)**      | Very Fast | ⭐⭐⭐☆☆               | Quick responses, simple tasks                 |
-| **Basic (o3-mini)**         | Fastest   | ⭐⭐☆☆☆               | Minimal processing, fast for easy tasks       |
+| Choice | When to use it |
+| --- | --- |
+| **Auto** (recommended) | Taskade picks a strong current model for your plan — you get upgrades automatically as better models ship |
+| **A frontier model** (e.g. the latest Claude or GPT) | Deep reasoning, complex analysis, agents whose answers you'll ship to customers |
+| **A fast/light model** | High-volume, quick-turnaround tasks where speed matters more than depth |
+| **An extended-thinking variant** | Multi-step problems that benefit from the model working through its reasoning |
+
+{% hint style="info" %}
+Agents pinned to a specific model stay on that model until you change it; **Auto** follows Taskade's current default for your plan.
+{% endhint %}
 
 ## Understanding Agent Knowledge & Memory
 

--- a/genesis-living-system-builder/automation/actions.md
+++ b/genesis-living-system-builder/automation/actions.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Complete Taskade automation action reference: create tasks, run AI agents, scrape web, send HTTP requests, integrate Slack, HubSpot, GitHub, and chain.
+  Complete Taskade automation action reference: create tasks, run AI agents, send HTTP requests, connect Slack and GitHub, and chain steps into workflows.
 ---
 
 # Action & Trigger Reference
@@ -49,7 +49,7 @@ Actions can be chained together to create complex multi-step workflows, with con
 | **Convert File to Text**     | Convert a source file into text                                               | Document processing, content extraction     | `fileId`, `outputFormat`, `encoding` |
 | **Transcribe YouTube Video** | Turn a YouTube video into text                                                | Content creation, accessibility             | `videoUrl`, `language`, `format`     |
 | **Upload File to Media**     | Upload file through a URL to save in your workspace or folder's media tab     | Media management, content storage           | `url`, `fileName`, `folderId`        |
-| **Send HTTP Request**        | Makes an API request to an endpoint                                           | External integrations, data synchronization | `method`, `url`, `headers`, `body`   |
+| **Send HTTP Request**        | Makes an API request to an endpoint; authentication is optional per call     | External integrations, data synchronization | `method`, `url`, `headers`, `body`, optional auth |
 | **Search Web**               | Searches the web for information to add to a project or for the AI to analyze | Research automation, content enrichment     | `query`, `sources`, `maxResults`     |
 
 ### Workflow Control Actions
@@ -541,7 +541,12 @@ Result: Current industry news awareness
 * **Rate Limiting**: Avoid overwhelming target servers
 * **Data Usage**: Ensure compliance with data protection regulations
 * **Attribution**: Properly credit sources when using scraped content
-* **Fair Use**: Use scraped data responsibly and ethically | **Convert File to Text** | Convert a source file into text | `fileUrl`, `fileType`, `extractImages` | Convert PDF manual to searchable text | | **Transcribe YouTube Video** | Turn a YouTube video into text | `videoUrl`, `language`, `includeTimestamps` | Create transcript of training video |
+* **Fair Use**: Use scraped data responsibly and ethically
+
+| Action | Description | Parameters | Example |
+|---|---|---|---|
+| **Convert File to Text** | Convert a source file into text | `fileUrl`, `fileType`, `extractImages` | Convert PDF manual to searchable text |
+| **Transcribe YouTube Video** | Turn a YouTube video into text | `videoUrl`, `language`, `includeTimestamps` | Create transcript of training video |
 
 ### Transcribe YouTube Video Automation Settings
 
@@ -782,7 +787,7 @@ The Generate Image with DALL·E 3 action creates beautiful images from text prom
 * Specify image format and intended use
 * Use descriptive adjectives for better results
 
-### Genesis — Image Format Conversion
+### Taskade Genesis — Image Format Conversion
 
 {% hint style="info" %}
 The **Image Format Conversion** action (available in Genesis flows) converts an image from one format to another entirely within Taskade — no external service required. Useful for normalizing images before uploading them to downstream steps.

--- a/genesis-living-system-builder/automation/integrations.md
+++ b/genesis-living-system-builder/automation/integrations.md
@@ -48,9 +48,9 @@ Taskade connects to **100+ tools and services** across communication, productivi
 | **Linear** | Issue created, updated | Create issue, update priority, assign | OAuth 2.0 / API Key |
 | **Asana** | Task created, completed | Create task, update project, assign | OAuth 2.0 / PAT |
 | **ClickUp** | Task created, task status changed | Create task, update task, delete task, add comment, get task, list tasks, find task by name, get task comments | OAuth 2.0 / API Key |
-| **Google Tasks** | Task created, task completed | Create task, update task, delete task, complete task, list tasks, clear completed, get task, find task | OAuth 2.0 |
+| **Google Tasks** | Task created, task completed | Create task, update task, delete task, complete task, re-open task, list tasks, clear completed, get task, find task | OAuth 2.0 |
 | **Monday.com** | Item created, updated | Create item, update status, notify | OAuth 2.0 / API Key |
-| **Todoist** | Task completed | Create task, update task, complete task, delete task, find task | OAuth 2.0 / API Key |
+| **Todoist** | Task completed | Create task, update task, complete task, re-open task, delete task, find task | OAuth 2.0 / API Key |
 | **Trello** | Card created, moved | Create card, move card, add member | OAuth 2.0 / API Key |
 
 ### Data & Analytics
@@ -97,7 +97,8 @@ Taskade connects to **100+ tools and services** across communication, productivi
 
 | Service | Triggers | Actions | Authentication |
 |---------|----------|---------|----------------|
-| **HTTP Webhooks** | Webhook received | Send HTTP request, POST data, call API | API Key / Bearer Token |
+| **HTTP Webhooks** | Webhook received | Send HTTP request, POST data, call API | Optional (Bearer / API Key / Basic) |
+| **IFTTT / Apple Shortcuts / n8n** | Webhook received | Call any of them via the HTTP request action — they're discoverable when searching automation actions | Webhook URL |
 | **REST APIs** | Custom endpoint called | Make API call, send data, receive response | Various |
 | **GraphQL** | Query executed | Execute query, mutation, subscription | API Key / OAuth |
 | **Custom Forms** | Form submitted | Process data, validate, route to workflow | None |
@@ -320,7 +321,7 @@ Lead Qualification Pipeline:
     - Calendar link for qualified prospects
     - Task creation for sales rep with context
 
-Business Impact: 300% increase in qualified meetings, 60% reduction in response time
+Business Impact: More qualified meetings booked, faster first response
 ```
 
 **Salesforce Account Management**
@@ -336,7 +337,7 @@ Customer Success Automation:
     - Alerts if risk factors detected
     - Prepares expansion opportunity analysis
 
-ROI: 85% renewal rate improvement, 40% expansion revenue increase
+ROI: Better renewal rates and expansion revenue through timely outreach
 ```
 
 ### **Microsoft Teams Enterprise Communication**

--- a/genesis-living-system-builder/community-and-sharing/README.md
+++ b/genesis-living-system-builder/community-and-sharing/README.md
@@ -26,7 +26,7 @@ Make your apps available to anyone with a link, creating public or private acces
 * **Direct Access**: Users can interact with your app through a dedicated URL
 * **No Installation Required**: Works immediately in any browser
 * **Version Control**: Update your published app while maintaining the same link
-* **Monetization Ready**: Foundation for future paywall and premium features
+* **Monetization Ready**: Sell paid apps with one-time Stripe checkout
 
 **Publishing Options:**
 
@@ -60,9 +60,9 @@ You can always unpublish your app if needed:
 
 **Note:** Unpublishing immediately removes public access, but the URL becomes inactive. Users who bookmarked the link will lose access.
 
-### **Enabling Cloning**
+### **Enabling Cloning (Forking)**
 
-Allow others to create complete copies of your app in their own workspaces.
+Allow others to create complete copies of your published app in their own workspaces. (When others copy your public app it's called **forking**; **cloning** also refers to duplicating your own app inside your workspace — the toggle below covers both.)
 
 **Cloning Features:**
 
@@ -164,12 +164,7 @@ Transform your Genesis apps into revenue-generating solutions with professional 
 
 ### **Monetize Your Expertise**
 
-Create premium Genesis apps that users pay to access:
-
-* **Subscription Models**: Monthly or yearly access to your app
-* **One-Time Purchases**: Pay once, use forever
-* **Tiered Access**: Different features for different price points
-* **Usage-Based Pricing**: Pay per transaction or interaction
+Create premium Taskade Genesis apps that users pay for: set a **one-time price** in your app's Publish settings, and buyers pay via **Stripe** to receive their own private copy of the app. See [Paid Apps](publish-and-clone.md#paid-apps) for the full flow.
 
 ### **Perfect for:**
 
@@ -195,11 +190,10 @@ Create premium Genesis apps that users pay to access:
 
 | Feature                   | Benefit                                           |
 | ------------------------- | ------------------------------------------------- |
-| **🔒 Access Control**     | Secure paywall integration with usage tracking    |
-| **📊 Analytics**          | Detailed metrics on user engagement and revenue   |
-| **💳 Payment Processing** | Seamless integration with Stripe and PayPal       |
+| **🔒 Access Control**     | Buyers receive their own private copy of the app  |
+| **📊 Analytics**          | Built-in metrics on views, likes, and installs    |
+| **💳 Payment Processing** | Payments handled by Stripe                        |
 | **🎨 Custom Branding**    | Your logo, colors, and domain                     |
-| **📈 A/B Testing**        | Optimize pricing and features for maximum revenue |
 
 ***
 
@@ -209,14 +203,18 @@ Share your AI expertise by embedding trained agents directly into websites, docu
 
 ### **Agents Anywhere**
 
-Your public AI agents can now be embedded with a simple code snippet:
+The agent **Share** panel includes an embed snippet builder — copy a ready-made snippet (inline iframe or floating chat widget) and customize the **launcher icon** and background to match your site. The generated iframe points at your agent's public URL:
 
 ```html
-<iframe src="https://agents.taskade.com/your-agent-id" 
-        width="400" height="600" 
-        frameborder="0">
+<iframe src="https://www.taskade.com/a/your-agent-id"
+        width="600" height="400"
+        frameborder="0"
+        allow="clipboard-read; clipboard-write"
+        allowfullscreen>
 </iframe>
 ```
+
+Copy the snippet from the Share panel rather than hand-writing it — the builder fills in the correct URL for your agent (including custom domains).
 
 ### **Use Cases**
 

--- a/genesis-living-system-builder/community-and-sharing/genesis-auth.md
+++ b/genesis-living-system-builder/community-and-sharing/genesis-auth.md
@@ -134,6 +134,7 @@ You don't need to know these details to use GenesisAuth, but they matter if you'
 * **Review exposed tools.** For public agents, opt sensitive tools out so external users can't invoke them.
 * **Suspend instead of delete** when you want to retain a user's history but block access.
 * **Use a custom domain with TLS** for any app that handles user data in production.
+* **OIDC sign-in is hardened by default.** OIDC lets workspaces gate app access behind their own identity provider; PKCE is an OAuth security check that stops intercepted sign-in codes from being replayed. Taskade accepts only the S256 PKCE method and validates that `redirect_uri` matches your app's own origin. See [Enterprise SSO (OIDC)](publish-and-clone.md#enterprise-sso-oidc) and the [authentication guide](../../apis-living-system-development/developers/authentication.md).
 * **Monitor sign-in activity** via the App Users tab and your workspace activity log.
 * **Rotate workspace tokens** periodically if you also expose the app via the [Public API](../../apis-living-system-development/developers/authentication.md).
 

--- a/genesis-living-system-builder/genesis/workspace-dna.md
+++ b/genesis-living-system-builder/genesis/workspace-dna.md
@@ -34,7 +34,7 @@ graph TD
 Projects store structured knowledge: tasks, notes, custom fields, documents, and media. This is what agents read and automations update.
 
 **What you get:**
-- 8 project views (List, Board, Calendar, Table, Mind Map, Gantt, Org Chart, Timeline)
+- 9 project views (List, Board, Calendar, Table, Mind Map, Gantt, Org Chart, Action, Docs)
 - Custom fields for structured data
 - Real-time sync across all devices
 - File and media uploads as active knowledge

--- a/genesis-living-system-builder/run-your-business/add-login-and-roles.md
+++ b/genesis-living-system-builder/run-your-business/add-login-and-roles.md
@@ -53,6 +53,20 @@ For the full walkthrough — the App Users tab, Workspace SSO, custom-domain sig
 
 ***
 
+## Give each user only their own rows
+
+For a client portal or member app, signed-in users usually shouldn't see each other's records. Turn on **Private per-user data** (row scoping) when you publish:
+
+1. Open your app's **publish menu** and enable **Private per-user data**. (The option appears for apps built on the current app template with sign-in enabled; turning it on rebuilds and republishes the app.)
+2. Pick — or add — a dedicated field on your project that stores each row's owner. Rows created **through the app** are tagged to the signed-in user automatically.
+3. Publish. Each signed-in user now sees only their own rows. Rows with no value in the owner field are hidden from app users entirely — the safe default.
+
+{% hint style="info" %}
+Before you launch, sign in as a test user and confirm they see only their own records — this pairs with the [go-live checklist](go-live-checklist.md) item on per-user data isolation. Data you add inside Taskade (rather than through the app) won't have an owner tag, so it stays hidden from app users until you assign one.
+{% endhint %}
+
+***
+
 ## Pair it with a custom domain
 
 GenesisAuth works on apps hosted at your own web address with no extra setup. Combining sign-in with a [custom domain](../space-apps-guide/custom-domains.md) gives end users a fully branded, production-ready product.

--- a/genesis-living-system-builder/space-apps-guide/custom-domains.md
+++ b/genesis-living-system-builder/space-apps-guide/custom-domains.md
@@ -4,7 +4,7 @@ description: Connect your own branded domain to a published Taskade Genesis app.
 
 # Custom Domains & Branding
 
-**Turn your Genesis apps from "homemade" looking tools into professional business software that looks like you spent a fortune to build it. Your customers will see your brand, not Taskade's.**
+**Turn your Taskade Genesis apps from "homemade" looking tools into professional business software that looks like you spent a fortune to build it. Your customers will see your brand, not Taskade's.**
 
 {% hint style="success" %}
 **Business plan feature.** Custom domains are available on the **Business plan and above**. Connect your own branded web address to a published Genesis app.
@@ -132,9 +132,9 @@ TTL: 3600 (or your registrar's default)
 3. **Wait for verification** (usually 5-15 minutes)
 4. **SSL certificate generates automatically**
 
-Domain validation and HTTPS now activate faster via Delegated DCV — Cloudflare handles certificate validation automatically on your behalf, so no extra DNS record is required.
+Domain validation and HTTPS now activate faster via Delegated DCV (Domain Control Validation) — Cloudflare proves you control the domain and issues the HTTPS certificate on your behalf, so no extra DNS record is required.
 
-#### 5. Assign to Genesis Apps
+#### 5. Assign to Taskade Genesis Apps
 
 1. **Open your Genesis app**
 2. **Click "Publish" dropdown**
@@ -180,7 +180,7 @@ Domain validation and HTTPS now activate faster via Delegated DCV — Cloudflare
 
 ### Setup with Cloudflare:
 
-1. **Ensure Domain is on Cloudflare** - Your domain must be managed by Cloudflare
+1. **Any DNS provider works** - Taskade serves custom domains through Cloudflare's network on your behalf; you do **not** need a Cloudflare account — any DNS provider that can create a CNAME record works
 2. **Add CNAME Record** - Point your subdomain to `custom-domains.taskade.com`
 3. **Enable SSL/TLS** - Cloudflare handles SSL certificate provisioning
 4. **Taskade Integration** - Connect domain in Taskade Custom Domains settings

--- a/genesis-living-system-builder/workspaces/editing-formatting.md
+++ b/genesis-living-system-builder/workspaces/editing-formatting.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Format Taskade tasks with headings, lists, highlights, and 8 project views, plus add-ons like due dates, timers, and keyboard shortcuts.
+  Format Taskade tasks with headings, lists, highlights, and 9 project views, plus add-ons like due dates, timers, and keyboard shortcuts.
 ---
 
 # Editing & Formatting
@@ -64,7 +64,7 @@ Taskade lets you turn tasks into checklists, headings, ordered lists, paragraphs
 
 ## Project Views
 
-The same content can be displayed in **8 different views** — switch anytime without changing your data:
+The same content can be displayed in **9 different views** — switch anytime without changing your data:
 
 | View | Description | Best For |
 |---|---|---|

--- a/genesis-living-system-builder/workspaces/projects-databases.md
+++ b/genesis-living-system-builder/workspaces/projects-databases.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Build Taskade database projects: custom fields, relationships, and 8 views. See how Genesis auto-generates schemas that power apps, agents, and automations.
+  Build Taskade database projects: custom fields, relationships, and 9 views. See how Taskade Genesis auto-generates schemas that power apps and agents.
 ---
 
 # Projects & Databases: The Memory Pillar
@@ -11,8 +11,8 @@ description: >-
 
 - [Overview](#overview)
 - [What Are Database Projects?](#what-are-database-projects)
-- [Taskade Genesis-Generated Databases](#genesis-generated-databases)
-- [8 Project Views](#id-8-project-views)
+- [Taskade Genesis-Generated Databases](#taskade-genesis-generated-databases)
+- [9 Project Views](#id-9-project-views)
 - [Manual Database Creation](#manual-database-creation)
 - [Importing Data](#importing-data)
 - [Automated App Workflows](#automated-app-workflows)
@@ -37,7 +37,7 @@ Database projects are structured data containers that serve as your app's persis
 
 | Feature | Description |
 |---|---|
-| **Custom fields** | Define field types: text, number, date, select, multi-select, checkbox, URL |
+| **Custom fields** | Define field types: text, number, currency, rating, date, select, multi-select, checkbox, URL, person |
 | **Relationships** | Link records across databases (e.g., customers ↔ orders) |
 | **Views** | List, board, table, calendar, and more |
 | **Filters & sorts** | Find and organize data dynamically |
@@ -48,7 +48,7 @@ Database projects are structured data containers that serve as your app's persis
 
 ---
 
-## Genesis-Generated Databases
+## Taskade Genesis-Generated Databases
 
 When Genesis builds an app, it **automatically creates the database structures** your app needs:
 
@@ -65,9 +65,9 @@ When Genesis builds an app, it **automatically creates the database structures**
 
 ---
 
-## 8 Project Views
+## 9 Project Views
 
-Every project database supports 8 different views — switch between them without changing your data:
+Every project database supports 9 different views — switch between them without changing your data:
 
 | View | Description | Best For |
 |---|---|---|
@@ -79,6 +79,7 @@ Every project database supports 8 different views — switch between them withou
 | **Mindmap** | Connected nodes radiating from center for visualization | Brainstorming, concept mapping, planning |
 | **Orgchart** | Hierarchical organizational structure | Team structure, process hierarchy |
 | **Action Sheet** | Compact action-oriented format | Quick task management |
+| **Docs (Beta)** | Continuous rich-text document editing | Specs, knowledge bases, long-form writing |
 
 > **Tip:** In Genesis apps, you can specify which view to use: "Display the customer database as a kanban board with columns for Lead, Qualified, Proposal, Won."
 
@@ -107,7 +108,8 @@ You can also create databases manually:
 | **Text (String)** | Names, descriptions, notes | Customer name, product description | Plain text |
 | **Number** | Quantities, prices, scores | Stock level, deal value, rating | Decimal, currency ($, EUR), percent (%) |
 | **Currency** | Pricing, invoices, budgets | Product price, invoice total, budget cap | Pre-formatted as USD; numeric field with currency symbol and decimal precision |
-| **DateTime** | Deadlines, timestamps, schedules | Due date, appointment time | Date only, date + time |
+| **DateTime** | Deadlines, timestamps, schedules | Due date, appointment time | Date only, date + time; Table view footers can aggregate Earliest / Latest / Range |
+| **Rating** | Feedback scores, priority ranking | Review stars, lead quality | Configurable star rating per row |
 | **Select** | Single-choice categories | Status, priority, category | Color-coded options |
 | **Multi-select** | Multiple tags/categories | Skills, interests, tags | Color-coded options |
 | **Checkbox** | Boolean yes/no states | Completed, approved, active | Toggle |

--- a/help-and-support/index/02_projects.md
+++ b/help-and-support/index/02_projects.md
@@ -26,7 +26,7 @@ A project in Taskade is a **flexible data container** that holds your informatio
 
 ```mermaid
 flowchart TD
-    DATA[Your Project Data<br/>Tree Structure] --> VIEWS[8 Different Views]
+    DATA[Your Project Data<br/>Tree Structure] --> VIEWS[9 Different Views]
 
     VIEWS --> LIST[📋 List View<br/>Hierarchical tasks]
     VIEWS --> BOARD[📊 Board View<br/>Kanban workflow]
@@ -113,7 +113,7 @@ Start with a task, note, or idea. Your project is now alive and ready to grow!
 
 **Boom!** You just created a living data container that can adapt to any workflow.
 
-## The 8 Project Views (Choose Your Perspective)
+## The 9 Project Views (Choose Your Perspective)
 
 Each view reveals different insights from your data. Here's when to use each one:
 

--- a/updates-and-timeline/changelog-2026/july-2026/README.md
+++ b/updates-and-timeline/changelog-2026/july-2026/README.md
@@ -1,0 +1,16 @@
+---
+description: >-
+  Taskade developer changelog for July 2026 — API, MCP, automation, agents, and Taskade Genesis updates.
+---
+
+# July 2026
+
+{% hint style="info" %}
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+{% endhint %}
+
+***
+
+## Releases this month
+
+* [July 1, 2026](july-1-2026.md) — Claude Sonnet 5 Joins the Model Lineup

--- a/updates-and-timeline/changelog-2026/july-2026/july-1-2026.md
+++ b/updates-and-timeline/changelog-2026/july-2026/july-1-2026.md
@@ -1,0 +1,35 @@
+---
+description: >-
+  Taskade developer changelog — July 1, 2026: Claude Sonnet 5 in the model pickers, agent embed snippet builder, smarter automation variable picker.
+---
+
+# July 1, 2026
+
+{% hint style="info" %}
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+{% endhint %}
+
+## What's New:
+
+### Claude Sonnet 5 Joins the Model Lineup
+
+Claude Sonnet 5 — including its extended-thinking variant — is now selectable across Taskade's AI model pickers, and **Auto** model selection for Taskade EVE and Genesis app building on most paid plans now defaults to it. Agents or automations pinned to a specific model are unchanged.
+
+***
+
+### Embed Your Agent Anywhere — Snippet Builder
+
+The agent **Share** panel now includes an embed snippet builder. Copy a ready-made code snippet to embed your public agent as a chat widget on any external site, and customize the **launcher icon** and background that visitors see. See [Publishing & Sharing](../../../genesis-living-system-builder/community-and-sharing/README.md).
+
+***
+
+### Smarter Automation Variable Picker
+
+When you're configuring a step in the flow editor, the variable picker now pre-loads the expected outputs of every preceding step — so you can reference upstream data before those steps have ever run.
+
+***
+
+## Improvements & Fixes:
+
+* Taskade Genesis app generation UI: refreshed theme bar, loaders, and publish menu.
+* General stability, performance, and connector reliability improvements.

--- a/updates-and-timeline/changelog-2026/june-2026/README.md
+++ b/updates-and-timeline/changelog-2026/june-2026/README.md
@@ -13,8 +13,11 @@ description: >-
 
 ## Releases this month
 
+* [June 30, 2026](june-30-2026.md) — Private Per-User Data for Taskade Genesis Apps
+* [June 29, 2026](june-29-2026.md) — Project Views, Redesigned
+* [June 28, 2026](june-28-2026.md) — Rating Field Type and MCP Sign-In from Cursor and VS Code
 * [June 23, 2026](june-23-2026.md) — Attach File to Task Action
-* [June 22, 2026](june-22-2026.md) — EVE Can Run a Saved Automation
+* [June 22, 2026](june-22-2026.md) — Taskade EVE Can Run a Saved Automation
 * [June 19, 2026](june-19-2026.md) — Utilities Piece: Data Transform Actions
 * [June 14, 2026](june-14-2026.md) — New Connectors: Microsoft Outlook, Todoist, ClickUp, Google Tasks, Google Docs
 * [June 9, 2026](june-9-2026.md) — Docs (Beta) and List View in Production

--- a/updates-and-timeline/changelog-2026/june-2026/june-28-2026.md
+++ b/updates-and-timeline/changelog-2026/june-2026/june-28-2026.md
@@ -1,0 +1,55 @@
+---
+description: >-
+  Taskade developer changelog — June 28, 2026: Rating field type, date column aggregations, MCP sign-in from Cursor and VS Code, and optional HTTP action auth.
+---
+
+# June 28, 2026
+
+{% hint style="info" %}
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+{% endhint %}
+
+## What's New:
+
+### Rating Custom Field Type
+
+Databases gain a **Rating** field type — a configurable star rating you can set per row, perfect for feedback scores, priority ranking, or quality reviews. Available in the field configurator alongside text, number, select, and the other field types. See [Projects & Databases](../../../genesis-living-system-builder/workspaces/projects-databases.md).
+
+***
+
+### Date Column Aggregations
+
+Table view date columns can now aggregate — show the **Earliest** date, **Latest** date, or the **Range** across all rows in the footer. Handy for deadline overviews and project timelines at a glance.
+
+***
+
+### MCP Sign-In from Cursor, VS Code, and Local Clients
+
+The hosted MCP server's OAuth **dynamic client registration** now accepts **Cursor**, **VS Code**, and loopback (localhost) redirect URIs — so those clients connect to [Taskade MCP](../../../apis-living-system-development/mcp-overview.md) with the standard sign-in flow, no manual client setup.
+
+***
+
+### Optional Authentication on the HTTP Action
+
+The **HTTP request** automation action now supports optional authentication — attach a **Bearer token**, **API key header**, or **Basic Auth** credentials (stored encrypted) when the endpoint needs them, or keep calls unauthenticated for public APIs. Previously, credentials had to be entered manually as headers. See the [Action Reference](../../../genesis-living-system-builder/automation/actions.md).
+
+***
+
+### Taskade EVE Shows Its Web Sources
+
+Taskade EVE's chat now displays **grounding sources for web research** — see which web pages and search results an answer drew from — plus a per-message usage chip.
+
+***
+
+### Taskade in 30 Languages, More Completely
+
+A major localization push translated the remaining interface backlog across **30 locales** — thousands of previously-English strings now render in your workspace language.
+
+***
+
+## Improvements & Fixes:
+
+* Taskade Genesis: refreshed recipe library and launcher, and published-app embeds now emit events for host-page integration.
+* Cloud file uploads are consistent across surfaces, with clearer validation for agent knowledge files.
+* Agent chat: thread tabs and composer menu polish.
+* General stability, performance, and connector reliability improvements.

--- a/updates-and-timeline/changelog-2026/june-2026/june-29-2026.md
+++ b/updates-and-timeline/changelog-2026/june-2026/june-29-2026.md
@@ -1,0 +1,37 @@
+---
+description: >-
+  Taskade developer changelog — June 29, 2026: redesigned project views, Re-open Task actions for Google Tasks and Todoist, and cleaner white-label agents.
+---
+
+# June 29, 2026
+
+{% hint style="info" %}
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+{% endhint %}
+
+## What's New:
+
+### Project Views, Redesigned
+
+All nine project views got a visual refresh for consistency — cleaner type scale, better spacing, improved accessibility, and a more polished compact editor across List, Board, Table, Calendar, Mind Map, Org Chart, Action, Gantt, and Docs. Same data, same interactions, sharper look. See [Project Views](../../../genesis-living-system-builder/workspaces/project-views.md).
+
+***
+
+### Re-open Task Action for Google Tasks and Todoist
+
+The **Google Tasks** and **Todoist** connectors each gain a **Re-open Task** action — flip a completed task back to open from any automation, keeping two-way task sync workflows honest. See [Supported Integrations](../../../genesis-living-system-builder/automation/integrations.md).
+
+***
+
+### Cleaner White-Label Agents
+
+When **Hide branding** is enabled for a published agent, the Taskade brand is now also stripped from that agent's underlying prompt — so a white-labeled agent won't identify itself as Taskade in conversation, matching the unbranded UI.
+
+***
+
+## Improvements & Fixes:
+
+* **IFTTT**, **Apple Shortcuts**, and **n8n** are now discoverable when searching automation actions — the HTTP request action connects to them via webhooks.
+* The **Task Completed** trigger now fires only for its configured project, as expected.
+* The AI prompt submit button now has an accessible label for screen readers.
+* General stability, performance, and connector reliability improvements.

--- a/updates-and-timeline/changelog-2026/june-2026/june-30-2026.md
+++ b/updates-and-timeline/changelog-2026/june-2026/june-30-2026.md
@@ -1,0 +1,35 @@
+---
+description: >-
+  Taskade developer changelog — June 30, 2026: private per-user data for Taskade Genesis apps, OIDC sign-in hardening, and static public/ folder support.
+---
+
+# June 30, 2026
+
+{% hint style="info" %}
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+{% endhint %}
+
+## What's New:
+
+### Private Per-User Data for Taskade Genesis Apps (Row Scoping)
+
+You can now turn on **Private per-user data** for a published Taskade Genesis app directly from the publish menu — no support ticket needed. Pick the project field that identifies each row's owner, and signed-in app users only see the rows that belong to them; rows created through the app are tagged to the signed-in user automatically. See [Add login and roles](../../../genesis-living-system-builder/run-your-business/add-login-and-roles.md).
+
+***
+
+### Hardened OIDC Sign-In for Taskade Genesis Apps
+
+OIDC sign-in for Taskade Genesis apps now rejects the insecure `plain` PKCE method (only **S256** is accepted) and strictly validates that `redirect_uri` matches the app's own origin. Standards-compliant integrations keep working unchanged. See [Genesis Authentication](../../../genesis-living-system-builder/community-and-sharing/genesis-auth.md).
+
+***
+
+### Static Files via public/ in the App Builder
+
+Taskade Genesis apps can now include a `public/` folder whose contents are passed straight through to the published app — drop in images, fonts, `robots.txt`, or other static assets and reference them by path.
+
+***
+
+## Improvements & Fixes:
+
+* Deleting a custom domain now shows its confirmation dialog correctly above the Settings modal.
+* General stability, performance, and connector reliability improvements.


### PR DESCRIPTION
## Developer changelog catch-up (June 24 – July 1) + docs polish

Brings the developer changelog current through **July 1** and polishes the pages each feature touches. Everything documented is the **public** product surface, verified against what actually shipped (flag-gated and internal work is excluded), and grouped by release date. **Zero rendering regression** (0 broken internal links; GitBook blocks balanced; SUMMARY targets verified).

### New changelog entries
- **June 28** — Rating custom field type; date column aggregations (Earliest/Latest/Range); MCP sign-in from Cursor, VS Code, and local clients; optional authentication on the HTTP action; Taskade EVE web grounding sources; 30-locale localization push.
- **June 29** — All nine project views redesigned; Re-open Task action (Google Tasks, Todoist); cleaner white-label agents.
- **June 30** — Private per-user data (row scoping) for published Taskade Genesis apps; hardened OIDC sign-in (S256-only PKCE, origin-validated redirects); static `public/` folder in the app builder.
- **July 1** (new month section) — Claude Sonnet 5 in the model pickers with Auto defaulting to it on most paid plans; agent embed snippet builder with launcher icons; smarter automation variable picker.

### Reference pages updated to match
Row-scoping how-to in *Add login and roles* (with the fail-safe behavior spelled out); field-types table gains Rating + date aggregations (and the views count reconciled to nine across pages); agent embed snippet guidance with a correct example; OIDC security note in *Genesis Authentication* with plain-language definitions; HTTP action + connector rows; IFTTT / Apple Shortcuts / n8n discoverability.

### DevEx / accuracy polish
- Agent model-selection guidance rewritten to be provider-current (was a stale single-provider table) with an Auto-first recommendation.
- Fixed a broken action-reference table that rendered as raw text; clarified that any DNS provider works for custom domains (no Cloudflare account needed); defined Delegated DCV on first use; aligned the paid-apps description with the actual Stripe one-time-purchase flow; clarified fork vs. clone terminology.
- Consistent Taskade Genesis / Taskade EVE naming in headings.

### Safety
Public surface only — no internal identifiers, no plan-internal details, no flag-gated features documented. Sensitivity and fabrication sweeps over the full diff are clean.

cc @deanzaka @lxcid
