### PR TITLE
docs: devex QA polish — rendering fixes, cleaner API/MCP references, consistent naming

### DIFF
--- a/apis-living-system-development/comprehensive-api-guide/README.md
+++ b/apis-living-system-development/comprehensive-api-guide/README.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Taskade REST API v1 reference — authenticate, then manage workspaces, projects, tasks, agents, folders, and media with full CRUD and an interactive explorer.
+  Taskade REST API v1 reference — authenticate, then manage workspaces, projects, tasks, agents, folders, and media with full CRUD and copy-paste code examples.
 ---
 
 # Comprehensive API Guide
@@ -17,10 +17,10 @@ The Taskade API is a RESTful web service that provides programmatic access to Ta
 
 ### Key Features
 
-* **🔗 RESTful Design**: Standard HTTP methods and status codes
-* **🔐 Secure Authentication**: OAuth 2.0 and Personal Access Token authentication
-* **📊 Complete CRUD Operations**: Full create, read, update, delete functionality
-* **📚 Comprehensive Documentation**: Detailed endpoint documentation
+* **RESTful Design**: Standard HTTP methods and status codes
+* **Secure Authentication**: OAuth 2.0 and Personal Access Token authentication
+* **Complete CRUD Operations**: Full create, read, update, delete functionality
+* **Comprehensive Documentation**: Detailed endpoint documentation
 
 ### API Base URL
 
@@ -44,10 +44,12 @@ curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 
 #### Obtaining a Personal Access Token
 
-1. Go to **Settings** → **Developer** → **Personal Access Tokens**
-2. Click **Generate New Token**
-3. Copy and securely store your token
-4. Use the token in the `Authorization` header
+1. Go to [taskade.com/settings/api](https://www.taskade.com/settings/api).
+2. Click **Create new token** and give it a descriptive name.
+3. Copy and securely store your token — it starts with the `tskdp_` prefix (you can hold up to 5 tokens per account).
+4. Use the token in the `Authorization` header.
+
+See the [Authentication](../developers/authentication.md) guide for OAuth 2.0 and full details.
 
 ### OAuth 2.0 Authentication
 
@@ -865,8 +867,8 @@ print(f"Found {len(workspaces['items'])} workspaces")
 
 ### Getting Help
 
-* **📧 Support**: support@taskade.com
-* **📚 Help Center**: [taskade.com/learn](https://www.taskade.com/learn)
+* **Support**: support@taskade.com
+* **Help Center**: [taskade.com/learn](https://www.taskade.com/learn)
 
 {% hint style="info" %}
 **Need more help?** Contact our support team for assistance with API integration or enterprise API requirements.

--- a/apis-living-system-development/genesis-app-mcp.md
+++ b/apis-living-system-development/genesis-app-mcp.md
@@ -1,7 +1,7 @@
 ---
 description: >-
   Connect Claude, Cursor, or any MCP client to your Taskade Genesis app's source
-  code via the hosted https://www.taskade.com/mcp server (OAuth 2.0, Business plan).
+  code via https://www.taskade.com/mcp (OAuth 2.0, Business plan).
 ---
 
 # Genesis App MCP (Beta)
@@ -157,9 +157,9 @@ Use whichever model your IDE supports — Claude Opus, GPT-4, Gemini, a local Ol
 - **Publish your changes.** Writing files through MCP updates your Genesis app's source, but you still need to publish/deploy the app through Taskade for the changes to go live on your custom domain. (Check your Genesis app's publish settings in Taskade.)
 - **No partial plans.** MCP access is gated at the workspace level. If you're a member of a Business workspace from a Pro account, you can use MCP against the Business workspace but not against your own Pro workspace.
 
-## When to use MCP vs. EVE
+## When to use MCP vs. Taskade EVE
 
-Both MCP and EVE (Taskade's in-product AI assistant) can edit your Genesis app. Use whichever fits your workflow:
+Both MCP and Taskade EVE (Taskade's in-product AI assistant) can edit your Taskade Genesis app. Use whichever fits your workflow:
 
 | Use **EVE** when… | Use **MCP** when… |
 |---|---|

--- a/apis-living-system-development/sdk-cookbook.md
+++ b/apis-living-system-development/sdk-cookbook.md
@@ -22,7 +22,7 @@ Production patterns for integrating with Taskade.
 - [Automations](#automations)
 - [Projects & Tasks](#projects-and-tasks)
 - [Webhooks](#webhooks)
-- [Bundles (Import/Export)](#bundles-importexport)
+- [Bundles (Import/Export)](#bundles-import-export)
 - [Error Handling Taxonomy](#error-handling-taxonomy)
 - [Pagination](#pagination)
 - [Testing & Mocking](#testing-and-mocking)

--- a/apis-living-system-development/workspace-mcp-advanced.md
+++ b/apis-living-system-development/workspace-mcp-advanced.md
@@ -229,7 +229,7 @@ MCP Connectors let your Taskade agents connect **outbound** to third-party servi
 
 <figure><img src="../.gitbook/assets/api-integrations-ecosystem.gif" alt="" width="563"><figcaption></figcaption></figure>
 
-Agents see enabled connectors as tools. You can opt specific tools out per agent (especially useful for public-facing agents).
+Agents see enabled connectors as tools. You can opt specific tools out per agent (especially useful for public-facing agents). See **[MCP Connectors](../genesis-living-system-builder/genesis/mcp-connectors.md)** for the full catalog and setup steps.
 
 ---
 

--- a/genesis-living-system-builder/ai-features/ai-agents-getting-started.md
+++ b/genesis-living-system-builder/ai-features/ai-agents-getting-started.md
@@ -150,10 +150,10 @@ Pick the best option for you:
 Give your AI assistant a clear role and personality - just like hiring a new team member:
 
 **Name:** Make it memorable and relevant\
-&#xNAN;_&#x45;xamples: "Sarah - Customer Success", "Marketing Mike", "Data Dave"_
+_Examples: "Sarah - Customer Success", "Marketing Mike", "Data Dave"_
 
 **Description:** Explain what your agent does\
-&#xNAN;_&#x45;xample: "You are a customer success specialist who helps clients get the most value from our product. You're friendly, knowledgeable, and always focused on solving problems."_
+_Example: "You are a customer success specialist who helps clients get the most value from our product. You're friendly, knowledgeable, and always focused on solving problems."_
 
 **Tone:** Choose how your agent should communicate
 

--- a/genesis-living-system-builder/automation/integrations.md
+++ b/genesis-living-system-builder/automation/integrations.md
@@ -321,7 +321,7 @@ Lead Qualification Pipeline:
     - Calendar link for qualified prospects
     - Task creation for sales rep with context
 
-Business Impact: More qualified meetings booked, faster first response
+Outcome: More qualified meetings booked, faster first response
 ```
 
 **Salesforce Account Management**
@@ -337,7 +337,7 @@ Customer Success Automation:
     - Alerts if risk factors detected
     - Prepares expansion opportunity analysis
 
-ROI: Better renewal rates and expansion revenue through timely outreach
+Outcome: Better renewal rates and expansion revenue through timely outreach
 ```
 
 ### **Microsoft Teams Enterprise Communication**

--- a/genesis-living-system-builder/community-and-sharing/README.md
+++ b/genesis-living-system-builder/community-and-sharing/README.md
@@ -8,7 +8,7 @@ description: >-
 **Turn your brilliant Taskade Genesis app into something that helps business owners everywhere. Share what you've built, discover amazing solutions from others, and copy complete apps with just one click.**
 
 {% hint style="success" %}
-**Latest Features!** Revolutionary app forking, embeddable public agents, and professional publishing with paywalls are now live! Share your Genesis apps globally, monetize premium solutions, and fork complete applications with one click.
+**What you can do here.** Publish your Taskade Genesis apps to the community, let others fork them in one click, and monetize premium apps with Stripe checkout.
 {% endhint %}
 
 ***
@@ -85,7 +85,7 @@ Allow others to create complete copies of your published app in their own worksp
 * Users should have immediate functionality without setup
 * You want to share proven, production-ready workflows
 
-## **Revolutionary App Forking**
+## App Forking
 
 The most powerful way to learn and build is by starting with working solutions. Genesis now lets you fork (copy) any community app with complete fidelity.
 
@@ -531,16 +531,18 @@ Understanding the differences helps you choose the right approach:
 
 ### Embedding Community Apps
 
-Some community apps include embeddable components:
+A published community app is a standard Taskade Genesis app, so you can embed it in any web page with an `<iframe>` that points at its public URL:
 
 ```html
-<!-- Embed a community feedback widget -->
-<iframe src="https://community-app.taskade.com/feedback-widget" 
-        width="400" 
-        height="600" 
+<!-- Embed a published community app -->
+<iframe src="https://www.taskade.com/a/your-app-id"
+        width="400"
+        height="600"
         frameborder="0">
 </iframe>
 ```
+
+Copy the exact URL from the app's **Share** panel.
 
 ### API Integration with Community Apps
 

--- a/genesis-living-system-builder/community-and-sharing/genesis-auth.md
+++ b/genesis-living-system-builder/community-and-sharing/genesis-auth.md
@@ -30,7 +30,7 @@ GenesisAuth is the authentication layer for apps built with Taskade Genesis. Whe
 * **Built-in user accounts.** No Auth0 or Clerk to wire up, no schema to design.
 * **Pre-built sign-in component** added to the generated app automatically.
 * **Scales with your app.** Handles sessions, password hashing, and session tokens securely.
-* **Turns every Genesis app into a real multi-user product.**
+* **Turns every Taskade Genesis app into a real multi-user product.**
 
 <figure><img src="../../.gitbook/assets/genesisauth-login-signup.jpg" alt="" width="563"><figcaption></figcaption></figure>
 
@@ -40,7 +40,7 @@ GenesisAuth is the authentication layer for apps built with Taskade Genesis. Whe
 
 You don't configure GenesisAuth manually — you describe the need.
 
-1. In Genesis, describe your app in plain language. Include phrases like:
+1. In Taskade Genesis, describe your app in plain language. Include phrases like:
    * *"a client portal where each client has their own dashboard"*
    * *"users can sign in to see their own habit streaks"*
    * *"a members-only knowledge base"*
@@ -50,14 +50,14 @@ You don't configure GenesisAuth manually — you describe the need.
 That's it. Your app now accepts user sign-ups, handles sign-in, and enforces per-user data access.
 
 {% hint style="info" %}
-If your first prompt doesn't trigger auth setup, you can add it later by asking EVE to *"add sign-in for users"* while editing the app.
+If your first prompt doesn't trigger auth setup, you can add it later by asking Taskade EVE to *"add sign-in for users"* while editing the app.
 {% endhint %}
 
 ---
 
 ## The App Users Tab
 
-The **App Users** tab lives in your Genesis app's settings. It's a first-class user management dashboard.
+The **App Users** tab lives in your Taskade Genesis app's settings. It's a first-class user management dashboard.
 
 ### What You Can Do
 

--- a/genesis-living-system-builder/genesis/workspace-dna.md
+++ b/genesis-living-system-builder/genesis/workspace-dna.md
@@ -180,6 +180,8 @@ Projects can function as databases with custom fields, turning simple task lists
 | **Date/Time** | Dates with optional time component |
 | **Select** | Dropdown with color-coded options |
 
+> This is a summary. See [Projects & Databases](../workspaces/projects-databases.md#available-field-types) for the full field-type reference — Rating, Currency, URL, Person, and more.
+
 **Why this matters:**
 
 - Store structured data alongside tasks and notes

--- a/genesis-living-system-builder/workspaces/projects-databases.md
+++ b/genesis-living-system-builder/workspaces/projects-databases.md
@@ -106,7 +106,7 @@ You can also create databases manually:
 | Field Type | Use Case | Example | Formatting Options |
 |---|---|---|---|
 | **Text (String)** | Names, descriptions, notes | Customer name, product description | Plain text |
-| **Number** | Quantities, prices, scores | Stock level, deal value, rating | Decimal, currency ($, EUR), percent (%) |
+| **Number** | Quantities, scores, counts | Stock level, quantity, score | Decimal, percent (%) |
 | **Currency** | Pricing, invoices, budgets | Product price, invoice total, budget cap | Pre-formatted as USD; numeric field with currency symbol and decimal precision |
 | **DateTime** | Deadlines, timestamps, schedules | Due date, appointment time | Date only, date + time; Table view footers can aggregate Earliest / Latest / Range |
 | **Rating** | Feedback scores, priority ranking | Review stars, lead quality | Configurable star rating per row |


### PR DESCRIPTION
Final devex QA pass on the live site after the recent merges synced to GitBook. Visual review with Playwright (desktop + mobile) across the changelog, workspaces, run-your-business, community, automation, MCP, and API pages, benchmarked against the Stripe/Notion/Figma bar.

**Automated sweep was clean** before this PR: 28 priority pages returned 200, 124 unique in-page internal links resolved (0 broken), and every Mermaid diagram renders as SVG. The changes below are the issues that only a human read of the rendered pages surfaces.

### Rendering fixes
- **ai-agents-getting-started** — remove a corrupted escaped-entity artifact that rendered as a literal `&#xNAN;` string before the Name/Description examples on this first-run page.
- **community-and-sharing** — replace a placeholder embed example that pointed at a non-existent host with the real published-app iframe form (`taskade.com/a/...`), and add a note to copy the exact URL from the Share panel.
- **sdk-cookbook** — fix a table-of-contents anchor that didn't match GitBook's generated heading slug (`#bundles-importexport` → `#bundles-import-export`).

### Developer reference polish
- **comprehensive-api-guide** — align the token-creation steps with the canonical Authentication page (`taskade.com/settings/api`, `tskdp_` prefix, 5-token limit) and link to it as the single source of truth; drop decorative emoji from Key Features / Getting Help to match the sibling reference pages; correct the meta description.
- **workspace-mcp-advanced** — link the on-page MCP Connectors section out to the full MCP Connectors page instead of dead-ending on an in-page anchor.
- **workspace-dna** — point the summary field-type table to the full Projects & Databases reference (Rating, Currency, URL, Person, and more).
- **projects-databases** — disambiguate the Number field from the dedicated Currency and Rating field types.

### Consistency
- **genesis-auth**, **genesis-app-mcp** — normalize first mentions to "Taskade Genesis" and "Taskade EVE".
- **integrations** — relabel promotional YAML comment keys to a neutral `Outcome:`.

### Zero-regression gate
- Link/anchor check: 0 broken internal links; the sdk-cookbook anchor above is now fixed (the 2 remaining flags are checker slug-guess false positives verified to resolve live).
- GitBook block balance, added-line sensitivity scan, frontmatter description lengths, and SUMMARY targets all pass.

Note: two Mermaid "non-render" reports during QA were verified as false positives — GitBook lazy-hydrates diagrams on scroll, so a full-page screenshot can capture a pre-hydration placeholder. Both the authentication PKCE and API v2 sequence diagrams render correctly for real users; left unchanged.