### PR TITLE
docs: TSK-1 launch + Jul 2–8 dev changelog catch-up + shorter URL slugs

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -5,16 +5,35 @@ structure:
   summary: SUMMARY.md
 
 redirects:
-  docs/updates: updates-and-timeline/changelog
-  docs/help-and-guides: help-and-support/index
-  docs/developer-api: apis-and-developer/developer-home
+  # Section renames (July 2026 slug optimization)
+  apis-and-developer: developers/developer-home
+  updates-and-timeline: changelog/changelog-2026
+  help-and-support: help/index
+  # Key sub-pages under renamed sections
+  apis-and-developer/developer-home: developers/developer-home
+  apis-and-developer/authentication: developers/authentication
+  apis-and-developer/comprehensive-api-guide: developers/comprehensive-api-guide
+  apis-and-developer/mcp-overview: developers/mcp-overview
+  apis-and-developer/workspace-mcp: developers/workspace-mcp
+  apis-and-developer/api-v2-reference: developers/api-v2-reference
+  updates-and-timeline/changelog: changelog/changelog
+  updates-and-timeline/changelog-2026: changelog/changelog-2026
+  updates-and-timeline/changelog-2026/july-2026: changelog/changelog-2026/july-2026
+  updates-and-timeline/changelog-2026/june-2026: changelog/changelog-2026/june-2026
+  updates-and-timeline/upcoming-changes: changelog/upcoming-changes
+  help-and-support/index: help/index
+  help-and-support/comprehensive-troubleshooting-guide: help/comprehensive-troubleshooting-guide
+  # Legacy redirects (pre-2026)
+  docs/updates: changelog/changelog-2026
+  docs/help-and-guides: help/index
+  docs/developer-api: developers/developer-home
   docs/genesis-no-code-apps: taskade-genesis/genesis
   help-center/ai-features: ai-features/ai-features
-  api-docs: apis-and-developer/developer-home
+  api-docs: developers/developer-home
   automation-guide: automations/automation
   mobile-guide: workspaces/workspaces/mobile-optimization
   integrations-guide: automations/automation/integrations
-  troubleshooting-guide: help-and-support/comprehensive-troubleshooting-guide
+  troubleshooting-guide: help/comprehensive-troubleshooting-guide
   best-practices-guide: community-and-sharing/community-and-sharing/best-practices
   templates-guide: taskade-genesis/genesis/examples-and-templates
   collaboration-guide: workspaces/workspaces/collaboration
@@ -32,10 +51,10 @@ redirects:
   genesis-ai: taskade-genesis/genesis
   ai-app-builder: taskade-genesis/genesis
   no-code-platform: taskade-genesis/genesis
-  tutorial-guide: help-and-support/index
-  comprehensive-api: apis-and-developer/comprehensive-api-guide
+  tutorial-guide: help/index
+  comprehensive-api: developers/comprehensive-api-guide
   industry-solutions: taskade-genesis/genesis/examples-and-templates
-  account-management: help-and-support/account-management
+  account-management: help/account-management
   vision: contributing/vision
 
 integrations:
@@ -60,15 +79,15 @@ navigation:
     - title: "🚀 Get Started"
       url: "https://www.taskade.com/"
     - title: "📚 API Documentation"
-      url: "/apis-and-developer"
+      url: "/developers"
     - title: "🎯 Features"
       url: "/taskade-genesis"
     - title: "⚡ Automations"
       url: "/automations"
     - title: "📰 Changelog"
-      url: "/updates-and-timeline"
+      url: "/changelog"
     - title: "🆘 Support"
-      url: "/help-and-support"
+      url: "/help"
     - title: "💬 Community"
       url: "https://www.taskade.com/community"
   

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -41,6 +41,7 @@
 
 * [AI Features Overview](genesis-living-system-builder/ai-features/README.md)
   * [AI Agents Getting Started](genesis-living-system-builder/ai-features/ai-agents-getting-started.md)
+  * [TSK-1 Model Tiers](genesis-living-system-builder/ai-features/tsk-1-model-tiers.md)
   * [Agent Knowledge & Memory](genesis-living-system-builder/ai-features/agent-knowledge.md)
   * [Tools for AI Agents](genesis-living-system-builder/ai-features/agent-tools.md)
   * [AI Agent Teams](genesis-living-system-builder/ai-features/agent-teams.md)
@@ -85,7 +86,7 @@
   * [FAQ](genesis-living-system-builder/community-and-sharing/faq.md)
   * [Troubleshooting](genesis-living-system-builder/community-and-sharing/troubleshooting.md)
 
-## APIs & Developer
+## Developers
 
 * [Developer Platform](apis-living-system-development/developer-home.md)
   * [Developer Overview](apis-living-system-development/developers/README.md)
@@ -175,11 +176,15 @@
 * [Long-Term Memory](apis-living-system-development/long-term-memory.md)
 * [Autonomous Agents](apis-living-system-development/autonomous-agents.md)
 
-## Updates & Timeline
+## Changelog
 
 * [Upcoming Changes](updates-and-timeline/upcoming-changes.md)
 * [Changelog (2026)](updates-and-timeline/changelog-2026/README.md)
   * [July 2026](updates-and-timeline/changelog-2026/july-2026/README.md)
+    * [July 8, 2026](updates-and-timeline/changelog-2026/july-2026/july-8-2026.md)
+    * [July 6, 2026](updates-and-timeline/changelog-2026/july-2026/july-6-2026.md)
+    * [July 4, 2026](updates-and-timeline/changelog-2026/july-2026/july-4-2026.md)
+    * [July 2, 2026](updates-and-timeline/changelog-2026/july-2026/july-2-2026.md)
     * [July 1, 2026](updates-and-timeline/changelog-2026/july-2026/july-1-2026.md)
   * [June 2026](updates-and-timeline/changelog-2026/june-2026/README.md)
     * [June 30, 2026](updates-and-timeline/changelog-2026/june-2026/june-30-2026.md)
@@ -269,7 +274,7 @@
   * [2020](changelog/2020/README.md)
   * [2017-2019](changelog/2017-2019/README.md)
 
-## Help & Support
+## Help
 
 * [Help Center](help-center/README.md)
   * [Import & Export](help-center/import-and-export.md)

--- a/genesis-living-system-builder/ai-features/ai-agents-getting-started.md
+++ b/genesis-living-system-builder/ai-features/ai-agents-getting-started.md
@@ -192,17 +192,18 @@ Make your agent smart by giving it information:
 
 ### Step 4.5: Choose Your AI Model
 
-Select the right AI model based on your needs. Taskade's model picker offers current frontier models from multiple providers — including the Claude, GPT, and Gemini families — and the lineup is refreshed as new models ship (see the [changelog](../../updates-and-timeline/changelog-2026/README.md) for additions):
+Taskade's model picker is powered by **TSK-1**, the intelligence layer that auto-routes every request to the right capability tier. You pick what you need the agent to do; TSK-1 handles which model executes it:
 
-| Choice | When to use it |
-| --- | --- |
-| **Auto** (recommended) | Taskade picks a strong current model for your plan — you get upgrades automatically as better models ship |
-| **A frontier model** (e.g. the latest Claude or GPT) | Deep reasoning, complex analysis, agents whose answers you'll ship to customers |
-| **A fast/light model** | High-volume, quick-turnaround tasks where speed matters more than depth |
-| **An extended-thinking variant** | Multi-step problems that benefit from the model working through its reasoning |
+| Tier | When to use it |
+|------|---------------|
+| **Auto** (recommended) | TSK-1 picks the right tier per request — fast when you need speed, deep when you need reasoning. New agents default to Auto on most paid plans |
+| **Instant** | Fast edits, simple completions, quick lookups |
+| **Standard** | Everyday work — balanced speed and reasoning |
+| **Thinking** | Planning, creation, multi-step reasoning |
+| **Reasoning** | Complex systems, deep analysis, multi-agent coordination |
 
 {% hint style="info" %}
-Agents pinned to a specific model stay on that model until you change it; **Auto** follows Taskade's current default for your plan.
+**Vendor-agnostic.** TSK-1 runs on the latest frontier models. The tier describes what the system is good at, not which provider powers it — providers may change. Agents pinned to a custom model (Max and Enterprise plans) bypass TSK-1 routing. See [TSK-1 Model Tiers](tsk-1-model-tiers.md) for the full reference.
 {% endhint %}
 
 ## Understanding Agent Knowledge & Memory

--- a/genesis-living-system-builder/ai-features/tsk-1-model-tiers.md
+++ b/genesis-living-system-builder/ai-features/tsk-1-model-tiers.md
@@ -1,0 +1,93 @@
+---
+description: >-
+  TSK-1 (Taskade System Kernel) is the intelligence layer that auto-routes AI work across four capability tiers — vendor-agnostic, always current.
+---
+
+# TSK-1 Model Tiers
+
+TSK-1 is not a single model. It is an **orchestration layer** — the intelligence system that coordinates how AI models, memory, agents, and workflows operate inside your workspace. When you pick a tier, TSK-1 routes your request to the best available model for that capability level.
+
+{% hint style="success" %}
+**The short version.** Set your agent to **Auto** and TSK-1 picks the right tier per request. The four tiers — Instant, Standard, Thinking, Reasoning — describe what the system is good at, not which provider powers it.
+{% endhint %}
+
+***
+
+## How TSK-1 fits in the stack
+
+```
+Taskade → Genesis → EVE → TSK-1 → Workspace DNA → Running workspace
+```
+
+TSK-1 sits between the **EVE** persona and **Workspace DNA** — it is the engine that decides *how* to execute a given request across the Memory (projects), Intelligence (agents), Execution (automations), and Apps (Genesis) pillars.
+
+***
+
+## The four tiers
+
+The model picker shows one TSK-1 header with a capability ladder. Each tier is defined by what it's good for, not by its underlying provider:
+
+| Tier | Best for | Example use |
+|------|----------|------------|
+| **Instant** | Fast edits, simple completions, quick lookups | Rename a task, fix a typo, categorize an item |
+| **Standard** | Everyday work — balanced speed and reasoning | Draft an email, summarize a document, answer a question |
+| **Thinking** | Planning, creation, multi-step reasoning | Design an automation flow, write a project proposal, generate a Genesis app |
+| **Reasoning** | Complex systems, deep analysis, multi-agent coordination | Audit a workspace, cross-reference databases, run a multi-agent team |
+
+***
+
+## Auto (recommended)
+
+Set your agent to **Auto** and TSK-1 dynamically routes each request to the appropriate tier — fast when you need speed, deep when you need reasoning. Auto is the default for new agents on most paid plans.
+
+Agents or automations **pinned to a specific tier** stay on that tier until you change them. The tier definitions are stable; the underlying models that serve each tier may change as the frontier improves.
+
+{% hint style="info" %}
+**Model lineup may change.** TSK-1 runs on the latest frontier models. Because the tiers describe capability rather than provider, Taskade can upgrade the underlying models without you needing to reconfigure anything. The in-app model picker always shows the current tier-to-model mapping.
+{% endhint %}
+
+***
+
+## When to pin a tier vs. use Auto
+
+| Scenario | Recommendation |
+|----------|---------------|
+| General-purpose agent — chat, answer questions, draft content | **Auto** — let TSK-1 decide |
+| High-volume automation that needs low latency and low cost | **Instant** or **Standard** |
+| Agent that designs workflows, apps, or complex plans | **Thinking** |
+| Agent that audits, cross-references, or coordinates other agents | **Reasoning** |
+| You have a specific model preference from prior testing | Custom model (available on Max and Enterprise plans) |
+
+Agents pinned to a **custom model** (e.g. a specific Claude or GPT version) bypass TSK-1 routing entirely — they always use that model. This is available on Max and Enterprise plans.
+
+***
+
+## Credits
+
+Each tier has its own per-token credit cost, shown in the in-app model picker. Auto routes to the tier it selects, billing at that tier's rate. Pinned custom models bill at the model's own rate.
+
+See [Credits & Billing](../../account-management/credits-and-billing.md) for current rates.
+
+***
+
+## Workspace DNA
+
+TSK-1 powers all four pillars of Workspace DNA:
+
+1. **Projects remember** — your data and context stay connected.
+2. **Agents reason** — multi-agent teams understand goals and take action.
+3. **Workflows run** — automations continue after chat ends.
+4. **Apps launch** — one prompt, one live app.
+
+For the full architecture, see [How Taskade Genesis Works](../genesis/how-genesis-works.md).
+
+***
+
+## What's next
+
+| Guide | What you'll learn |
+|-------|------------------|
+| [AI Agents Getting Started](ai-agents-getting-started.md) | Set up your first agent and choose a TSK-1 tier |
+| [Agent Knowledge & Memory](agent-knowledge.md) | Give agents context from your projects |
+| [Multi-Agent Collaboration](multi-agents.md) | Coordinate multiple agents with TSK-1 Reasoning |
+| [Credits & Billing](../../account-management/credits-and-billing.md) | Understand credit costs per tier |

--- a/genesis-living-system-builder/automation/actions.md
+++ b/genesis-living-system-builder/automation/actions.md
@@ -48,6 +48,7 @@ Actions can be chained together to create complex multi-step workflows, with con
 | **Scrape Webpage**           | Extract the contents of a web page                                            | Content aggregation, research               | `url`, `selectors`, `format`         |
 | **Convert File to Text**     | Convert a source file into text                                               | Document processing, content extraction     | `fileId`, `outputFormat`, `encoding` |
 | **Transcribe YouTube Video** | Turn a YouTube video into text                                                | Content creation, accessibility             | `videoUrl`, `language`, `format`     |
+| **Transcribe Audio to Project** | Convert uploaded audio into project text                                   | Meeting notes, voice memos, podcast indexing | `fileId`, `language`, `outputFormat`  |
 | **Upload File to Media**     | Upload file through a URL to save in your workspace or folder's media tab     | Media management, content storage           | `url`, `fileName`, `folderId`        |
 | **Send HTTP Request**        | Makes an API request to an endpoint; authentication is optional per call     | External integrations, data synchronization | `method`, `url`, `headers`, `body`, optional auth |
 | **Search Web**               | Searches the web for information to add to a project or for the AI to analyze | Research automation, content enrichment     | `query`, `sources`, `maxResults`     |
@@ -547,6 +548,7 @@ Result: Current industry news awareness
 |---|---|---|---|
 | **Convert File to Text** | Convert a source file into text | `fileUrl`, `fileType`, `extractImages` | Convert PDF manual to searchable text |
 | **Transcribe YouTube Video** | Turn a YouTube video into text | `videoUrl`, `language`, `includeTimestamps` | Create transcript of training video |
+| **Transcribe Audio to Project** | Convert uploaded audio into project text | `fileId`, `language`, `outputFormat` | Turn voice memo into project notes |
 
 ### Transcribe YouTube Video Automation Settings
 

--- a/genesis-living-system-builder/workspaces/projects-databases.md
+++ b/genesis-living-system-builder/workspaces/projects-databases.md
@@ -115,6 +115,7 @@ You can also create databases manually:
 | **Checkbox** | Boolean yes/no states | Completed, approved, active | Toggle |
 | **URL** | Web links | Website, profile link | Clickable link |
 | **Person** | Team member assignment | Assignee, reviewer, owner | Workspace member picker |
+| **Relationship** | Link records across projects | Customer → Orders, Lead → Deals | Cross-project record picker |
 
 ### Task Addons (Beyond Custom Fields)
 

--- a/updates-and-timeline/changelog-2026/july-2026/README.md
+++ b/updates-and-timeline/changelog-2026/july-2026/README.md
@@ -13,4 +13,8 @@ description: >-
 
 ## Releases this month
 
+* [July 8, 2026](july-8-2026.md) — Multi-Select Field, IA Sidebar Tabs, New MCP Tools & Automade Triggers
+* [July 6, 2026](july-6-2026.md) — Relationship Field Type, Table Multi-Cell Copy/Paste, HTTP Webhook Triggers
+* [July 4, 2026](july-4-2026.md) — TSK-1: The Taskade System Kernel
+* [July 2, 2026](july-2-2026.md) — Workspace DNA Live, Transcribe Audio Action, EVE Auto Row-Scoping
 * [July 1, 2026](july-1-2026.md) — Claude Sonnet 5 Joins the Model Lineup

--- a/updates-and-timeline/changelog-2026/july-2026/july-2-2026.md
+++ b/updates-and-timeline/changelog-2026/july-2026/july-2-2026.md
@@ -1,0 +1,42 @@
+---
+description: >-
+  Taskade developer changelog — July 2, 2026: Workspace DNA is live for everyone, Transcribe Audio to Project action, and EVE auto-enables per-user data privacy.
+---
+
+# July 2, 2026
+
+{% hint style="info" %}
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+{% endhint %}
+
+## What's New:
+
+### Workspace DNA Is Live for Everyone
+
+The **Workspace DNA** structured map — a live overview of every project schema, agent, automation flow, and published app in your space — is now available on all plans. Previously in beta, it gives you a single view of how your workspace's Memory, Intelligence, and Execution pillars connect. See [How Taskade Genesis Works](../../../genesis-living-system-builder/genesis/how-genesis-works.md).
+
+***
+
+### Transcribe Audio to Project
+
+A new **Transcribe Audio** automation action converts uploaded audio files into project text. Find it in the Add Action dialog alongside the existing Convert File to Text and Transcribe YouTube actions. See the [Action Reference](../../../genesis-living-system-builder/automation/actions.md).
+
+***
+
+### EVE Auto-Enables Per-User Data Privacy
+
+When Taskade EVE generates a Genesis app, it now automatically turns on **Private per-user data** (row scoping) for apps that need it — no extra prompt or publish-menu toggle required. This pairs with the existing manual toggle. See [Add Login & Roles](../../../genesis-living-system-builder/run-your-business/add-login-and-roles.md).
+
+***
+
+### Cleaner Automation Trigger Keys
+
+Automation triggers now accept **bare `@field_id` keys** as aliases alongside the full namespaced path `trigger["projectId/fields/@field_id"]` — shorter LiquidJS templates with the same behavior.
+
+***
+
+## Improvements & Fixes:
+
+* `.wav` file uploads no longer produce a 500 error; errors are surfaced properly.
+* Genesis app form submissions (Parade runtime) correctly forward refs so generated forms work on first submit.
+* General stability, performance, and connector reliability improvements.

--- a/updates-and-timeline/changelog-2026/july-2026/july-4-2026.md
+++ b/updates-and-timeline/changelog-2026/july-2026/july-4-2026.md
@@ -1,0 +1,54 @@
+---
+description: >-
+  Taskade developer changelog — July 4, 2026: TSK-1 (Taskade System Kernel) launches — an intelligence layer that auto-routes across four capability tiers underneath every AI agent, automation, and Genesis app.
+---
+
+# July 4, 2026
+
+{% hint style="info" %}
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+{% endhint %}
+
+## What's New:
+
+### TSK-1: The Taskade System Kernel
+
+**TSK-1** is the intelligence layer that coordinates models, memory, agents, and workflows across your workspace. It is not a single model — it is an orchestration layer that dynamically routes each request to the right capability tier underneath. As underlying models improve, TSK-1's tier definitions stay stable; what changes is which model serves each tier.
+
+The model picker now shows a **TSK-1** header with four capability tiers:
+
+| Tier | Best for |
+|------|----------|
+| **Instant** | Fast edits, simple completions, quick lookups |
+| **Standard** | Everyday work — balanced speed and reasoning |
+| **Thinking** | Planning, creation, multi-step reasoning |
+| **Reasoning** | Complex systems, deep analysis, multi-agent coordination |
+
+Plus **Auto** — the recommended default — which picks the right tier per request. Agents or automations pinned to a specific model are unchanged; new agents default to Auto.
+
+{% hint style="info" %}
+**Vendor-agnostic.** TSK-1 runs on the latest frontier models. The tier describes what the system is good at, not which provider powers it — providers may change as the landscape evolves. See [TSK-1 Model Tiers](../../../genesis-living-system-builder/ai-features/tsk-1-model-tiers.md) for the full reference.
+{% endhint %}
+
+***
+
+### Workspace DNA Framework
+
+The **Workspace DNA** framework is now the unified architecture underneath every Taskade workspace:
+
+1. **Projects remember** — your data and context stay connected.
+2. **Agents reason** — multi-agent teams understand goals and take action.
+3. **Workflows run** — automations continue after chat ends.
+4. **Apps launch** — one prompt, one live app.
+
+TSK-1 sits between the EVE persona and Workspace DNA, coordinating how intelligence flows through all four pillars. See [How Taskade Genesis Works](../../../genesis-living-system-builder/genesis/how-genesis-works.md).
+
+***
+
+## Improvements & Fixes:
+
+* Agent Teams create/edit/delete dialogs now match the editor chat experience.
+* Public agent knowledge respects per-user row-scoped data — rows hidden from a user are never surfaced in agent answers.
+* Automation AI structured output now routes through function-calling for better schema adherence.
+* Auth hardening: PAT bearer verification and OAuth2 JWT-ID validation tightened.
+* General stability, performance, and connector reliability improvements.

--- a/updates-and-timeline/changelog-2026/july-2026/july-6-2026.md
+++ b/updates-and-timeline/changelog-2026/july-2026/july-6-2026.md
@@ -1,0 +1,38 @@
+---
+description: >-
+  Taskade developer changelog — July 6, 2026: Relationship field type links records across databases, Table View multi-cell copy/paste, and HTTP webhook triggers now fire correctly.
+---
+
+# July 6, 2026
+
+{% hint style="info" %}
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+{% endhint %}
+
+## What's New:
+
+### Relationship Field Type (Phase 1)
+
+Databases gain a **Relationship** field type that links records across projects — think customers ↔ orders or leads ↔ deals. Phase 1 ships the field renderer, configurator, and schema serialization; future phases will add lookup columns and cross-project filtering. See [Projects & Databases](../../../genesis-living-system-builder/workspaces/projects-databases.md).
+
+***
+
+### Table View Multi-Cell Copy/Paste
+
+Select a **range of cells** in Table View, copy (TSV on the clipboard), and paste into another range — edits are bundled into a single changeset. Works across number, text, select, and date columns.
+
+***
+
+### HTTP Webhook Triggers Now Fire
+
+Automation flows triggered by an incoming HTTP webhook now work correctly by honoring the connection's `authDesc.required` field — no more silent no-ops on webhook-triggered workflows.
+
+***
+
+## Improvements & Fixes:
+
+* Select field values in the Genesis app data gateway now serialize as human-readable labels instead of raw field IDs.
+* Duplicate automation node additions are rejected to prevent flow corruption.
+* Loop iteration results now persist through execution instead of being discarded between iterations.
+* Genesis build errors carry their error taxonomy through to the publish pipeline so causes are visible in published apps.
+* General stability, performance, and connector reliability improvements.

--- a/updates-and-timeline/changelog-2026/july-2026/july-8-2026.md
+++ b/updates-and-timeline/changelog-2026/july-2026/july-8-2026.md
@@ -1,0 +1,69 @@
+---
+description: >-
+  Taskade developer changelog — July 8, 2026: Multi-Select field type, new Agent/Team/Automation sidebar tabs, two new MCP tools, and expanded automade trigger catalog.
+---
+
+# July 8, 2026
+
+{% hint style="info" %}
+**Developer highlights.** This section tracks API, MCP, SDK, automation, and Taskade Genesis platform changes for developers. For the full product changelog see [taskade.com/changelog](https://www.taskade.com/changelog); for release newsletters see [taskade.com/blog/updates](https://www.taskade.com/blog/updates).
+{% endhint %}
+
+## What's New:
+
+### Multi-Select Field Type
+
+Table View databases now support a **Multi-Select** field type — tag a row with multiple values from a defined option list, with range selection support. Available alongside the existing Select (single-choice) field in the field configurator. See [Projects & Databases](../../../genesis-living-system-builder/workspaces/projects-databases.md).
+
+***
+
+### Agent, Team & Automation Sidebar Tabs
+
+The space sidebar now has dedicated **IA tabs** for Agents, Agent Teams, and Automations — one-click access instead of hunting through menus. Each tab surfaces its own list with search and create actions.
+
+***
+
+### Two New MCP Tools
+
+The hosted MCP server at [Taskade MCP](https://www.taskade.com/mcp) gains two new tools:
+
+| Tool | What it does |
+|------|-------------|
+| `edit_app_file` | Edit a published Taskade Genesis app's source files from your IDE or AI client — make changes without leaving your editor, then publish through Taskade. |
+| `set_project_archived` | Archive or restore a project programmatically. |
+
+Both are available to any MCP client connected to your workspace. See [Workspace MCP](../../../apis-living-system-development/workspace-mcp.md).
+
+***
+
+### Expanded Automade Trigger Catalog
+
+The automation piece registry now includes new triggers:
+
+| Trigger | What it fires on |
+|---------|-----------------|
+| **HTTP `sendRequest`** | Outbound HTTP calls with proper auth handling |
+| **Slack `newMessage`** | New messages in a Slack channel |
+| **Trello `newCard`** | New cards created on a Trello board |
+| **Rating field change** | A Rating field value changes |
+| **Relationship field change** | A Relationship field value changes |
+
+See the [Integration Overview](../../../genesis-living-system-builder/automation/comprehensive-integration-guide.md).
+
+***
+
+### Genesis App Builder Visual Overhaul
+
+The Genesis app generator received a redesigned preview, loading states, error states, and empty-state illustrations — plus refreshed analytics, tabs, and user-management UI.
+
+***
+
+## Improvements & Fixes:
+
+* Table View snap on Chrome cell-click fixed.
+* Multi-cell range paste now works across number, text, select, and date columns.
+* Empty push notifications for unknown activity types are suppressed.
+* Deactivated Taskade Actions no longer appear in the space-agent dropdown.
+* Single-select field values map correctly into Add Task automation flows.
+* Breadcrumb overflow now scrolls horizontally instead of clipping.
+* General stability, performance, and connector reliability improvements.


### PR DESCRIPTION
Developer changelog catch-up from v6.198 through v6.203 (Jul 2–8), headlined by the TSK-1 launch plus new field types, MCP tools, and a URL slug pass.

### Changelog entries (4 new)
- **Jul 2** — Workspace DNA live, Transcribe Audio to Project action, EVE auto row-scoping, cleaner trigger field-key aliases
- **Jul 4** — TSK-1 launches: an intelligence layer that auto-routes across four capability tiers (Instant, Standard, Thinking, Reasoning) plus Auto — vendor-agnostic, always current
- **Jul 6** — Relationship field type, Table View multi-cell copy/paste, HTTP webhook triggers fixed
- **Jul 8** — Multi-Select field type, Agent/Team/Automation sidebar tabs, two new MCP tools (`edit_app_file`, `set_project_archived`), expanded automade triggers (HTTP sendRequest, Slack newMessage, Trello newCard, Rating + Relationship field triggers)

### New reference page
- **TSK-1 Model Tiers** — what TSK-1 is, how the tier ladder works, when to use Auto vs. pin a tier, where it fits in the Workspace DNA architecture

### Updated reference pages
- ai-agents-getting-started: model selection table → TSK-1 tier ladder
- projects-databases: added Relationship field type
- actions.md: added Transcribe Audio to Project action

### URL slugs — shorter section headers
- "Updates & Timeline" → "Changelog" (`/changelog/`)
- "Help & Support" → "Help" (`/help/`)
- "APIs & Developer" → "Developers" (`/developers/`)
- `.gitbook.yaml`: nav links + redirects updated for section entry points and key sub-pages

### Gate
- TOC anchors: all self-consistent; block balance: clean; sensitivity: clean; SUMMARY targets: all present