### PR TITLE
docs: final visual QA polish — SEO, naming, redirect fixes

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -9,6 +9,7 @@ redirects:
   apis-and-developer: developers/developer-home
   updates-and-timeline: changelog/changelog-2026
   help-and-support: help/index
+  help-and-support/index: help/index
   # Key sub-pages under renamed sections
   apis-and-developer/developer-home: developers/developer-home
   apis-and-developer/authentication: developers/authentication

--- a/apis-living-system-development/comprehensive-api-guide/README.md
+++ b/apis-living-system-development/comprehensive-api-guide/README.md
@@ -3,7 +3,7 @@ description: >-
   Taskade REST API v1 reference — authenticate, then manage workspaces, projects, tasks, agents, folders, and media with full CRUD and copy-paste code examples.
 ---
 
-# Comprehensive API Guide
+# REST API v1 Reference
 
 Build powerful integrations with Taskade's REST API. Access projects, tasks, agents, and more programmatically with full CRUD operations.
 
@@ -830,7 +830,7 @@ class TaskadeClient:
         return response.json()
 
 # Usage
-client = TaskadeClient('your_token')
+client = TaskadeClient('YOUR_ACCESS_TOKEN')
 workspaces = client.get_workspaces()
 print(f"Found {len(workspaces['items'])} workspaces")
 ```

--- a/apis-living-system-development/developer-home.md
+++ b/apis-living-system-development/developer-home.md
@@ -1,5 +1,5 @@
 ---
-description: Everything you need to build on Taskade — REST API, MCP Server, SDK, and more.
+description: Everything you need to build on Taskade — REST API v1, Action API v2, MCP Server, OAuth 2.0, webhooks, and hosted MCP for Taskade Genesis apps.
 ---
 
 # Developer Platform

--- a/apis-living-system-development/mcp-overview.md
+++ b/apis-living-system-development/mcp-overview.md
@@ -1,7 +1,7 @@
 ---
 description: >-
   Three Taskade MCP surfaces, one decision. Pick the right one by what you want
-  to do.
+  to do — hosted MCP, Workspace MCP for IDEs, or @taskade/mcp-server package.
 ---
 
 # Which Taskade MCP do I want?

--- a/genesis-living-system-builder/ai-features/ai-agents-getting-started.md
+++ b/genesis-living-system-builder/ai-features/ai-agents-getting-started.md
@@ -336,7 +336,7 @@ Give your agent specific skills with custom commands:
 
 ## **Enhanced File Attachments**
 
-TAA conversations now support rich file interactions with complete visibility and context.
+TAA (Taskade AI Assistant) conversations now support rich file interactions with complete visibility and context.
 
 ### **Drag & Drop File Magic**
 
@@ -598,7 +598,7 @@ Ready to build your AI team?
 * [Watch tutorial videos](https://youtube.com/taskade) for step-by-step guides
 * [Join our community](https://taskade.com/community) to share and learn
 
-## Next Steps
+## Taking It Further
 
 ### **Build Without Permission**
 

--- a/genesis-living-system-builder/space-apps-guide/custom-domains.md
+++ b/genesis-living-system-builder/space-apps-guide/custom-domains.md
@@ -1,5 +1,5 @@
 ---
-description: Connect your own branded domain to a published Taskade Genesis app.
+description: Connect your own branded domain to a published Taskade Genesis app — set up DNS, enable SSL, and go live on your own URL in minutes.
 ---
 
 # Custom Domains & Branding

--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -34,7 +34,7 @@ Learn more: [Workspace DNA](https://www.taskade.com/learn/genesis/workspace-dna)
 2. **Name your workspace** — this becomes the home for all your apps
 3. **Verify your email** — check your inbox and click the confirmation link
 
-## Build Your First App with Genesis (5 minutes)
+## Build Your First App with Taskade Genesis (5 minutes)
 
 **This is where the magic happens.** Instead of managing tasks manually, let's build an app that solves a real business problem. You can [start building your first app with Taskade Genesis](https://www.taskade.com/create) directly from your workspace.
 

--- a/updates-and-timeline/changelog-2026/july-2026/july-4-2026.md
+++ b/updates-and-timeline/changelog-2026/july-2026/july-4-2026.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Taskade developer changelog — July 4, 2026: TSK-1 (Taskade System Kernel) launches — an intelligence layer that auto-routes across four capability tiers underneath every AI agent, automation, and Genesis app.
+  TSK-1 (Taskade System Kernel) launches — an intelligence layer that auto-routes AI work across four capability tiers for agents, automations, and Genesis apps.
 ---
 
 # July 4, 2026

--- a/updates-and-timeline/changelog-2026/july-2026/july-6-2026.md
+++ b/updates-and-timeline/changelog-2026/july-2026/july-6-2026.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Taskade developer changelog — July 6, 2026: Relationship field type links records across databases, Table View multi-cell copy/paste, and HTTP webhook triggers now fire correctly.
+  Relationship field type links records across databases, Table View multi-cell copy/paste, and HTTP webhook triggers now fire correctly.
 ---
 
 # July 6, 2026

--- a/updates-and-timeline/changelog-2026/july-2026/july-8-2026.md
+++ b/updates-and-timeline/changelog-2026/july-2026/july-8-2026.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Taskade developer changelog — July 8, 2026: Multi-Select field type, new Agent/Team/Automation sidebar tabs, two new MCP tools, and expanded automade trigger catalog.
+  Multi-Select field type, Agent/Team/Automation sidebar tabs, new MCP tools, and expanded automation trigger catalog.
 ---
 
 # July 8, 2026


### PR DESCRIPTION
Final visual QA sweep after the TSK-1 launch + section renames. Automated sweep: 38 priority pages all 200, zero broken images, zero raw GitBook syntax, all Mermaid SVGs render.

### Fixes from 6-agent visual QA review

**SEO**
- Trim 3 overlong changelog meta descriptions to ≤160 chars (july-4, july-6, july-8)
- Enrich 3 short meta descriptions (custom-domains, developer-home, mcp-overview)

**Naming & structure**
- Fix bare "Genesis" → "Taskade Genesis" in quickstart H2
- Define "TAA" (Taskade AI Assistant) abbreviation on first use
- Rename duplicate "Next Steps" heading → "Taking It Further" to avoid confusing readers
- Align comprehensive-api-guide H1 with SUMMARY.md label ("REST API v1 Reference")

**Consistency**
- Standardize Python placeholder token to `YOUR_ACCESS_TOKEN`
- Add edge-case redirect: `help-and-support/index` → `help/index`
- Scrub internal name "automade" from july-8 meta description

### Gate
Block balance, description lengths (all ≤160), leak scan, SUMMARY targets — all PASS (0 issues)