### PR TITLE
docs: final QA polish — naming consistency, mobile table fit, redirects

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -17,6 +17,8 @@ redirects:
   apis-and-developer/mcp-overview: developers/mcp-overview
   apis-and-developer/workspace-mcp: developers/workspace-mcp
   apis-and-developer/api-v2-reference: developers/api-v2-reference
+  ai-features/tsk-1-model-tiers: ai-features/ai-features/tsk-1-model-tiers
+  developers/genesis-app-mcp: developers/workspace-mcp/genesis-app-mcp
   updates-and-timeline/changelog: changelog/changelog
   updates-and-timeline/changelog-2026: changelog/changelog-2026
   updates-and-timeline/changelog-2026/july-2026: changelog/changelog-2026/july-2026

--- a/apis-living-system-development/mcp-overview.md
+++ b/apis-living-system-development/mcp-overview.md
@@ -10,7 +10,7 @@ Taskade speaks MCP (Model Context Protocol) through **three** surfaces. Pick by 
 
 | I want to… | Use | Where / auth |
 |---|---|---|
-| Have Claude **read & write my tasks** — create, complete, assign, set dates and fields | **[Workspace MCP](workspace-mcp.md)** (`@taskade/mcp-server`) | Local stdio · personal token (`https://www.taskade.com/settings/api`) · any paid plan |
+| Have Claude **read & write my tasks** — create, complete, assign, set dates and fields | **[Workspace MCP](workspace-mcp.md)** (`@taskade/mcp-server`) | Local stdio · personal token ([settings/api](https://www.taskade.com/settings/api)) · any paid plan |
 | **Orchestrate my workspace from my IDE** — create projects, manage & prompt agents, edit my app's code | **[Hosted Taskade MCP](genesis-app-mcp.md)** | Hosted · OAuth 2.0 (`https://www.taskade.com/mcp`) · any paid plan |
 | Let my agents **reach Slack, Shopify, Gmail** & other tools | **[MCP Connectors](../genesis-living-system-builder/genesis/mcp-connectors.md)** | Hosted, in-product |
 

--- a/apis-living-system-development/webhooks.md
+++ b/apis-living-system-development/webhooks.md
@@ -256,11 +256,11 @@ Reject any delivery whose signature doesn't match.
 | Target URL | Must be **`https`** (deliveries use an SSRF-guarded fetch). Max **2,048 characters** URL-encoded. |
 | Limit | Up to **100** event–workspace combinations per account across your registered webhooks (a webhook with 3 events scoped to 2 workspaces counts as 6). |
 | Scope | All workspaces by default; narrow with `spaceIds`. |
-| Dashboard | You can also create and manage outgoing webhooks in **[Settings → API](https://www.taskade.com/settings/api)**. |
+| Dashboard | You can also create and manage outgoing webhooks in **[Settings > API](https://www.taskade.com/settings/api)**. |
 
 ### Legacy: unsigned subscriptions (deprecated)
 
-`POST /api/v2/subscribeWebhook` (`{ targetUrl, triggerType }` → `{ ok, hookId }`) and `POST /api/v2/unsubscribeWebhook` (`{ hookId }`) still work, but they are **deprecated**: each subscription covers a single event, scoping is account-level only, and deliveries are **not signed**. New integrations should use `POST /api/v2/webhooks`; existing ones can migrate by registering the same target URL with the new endpoint and removing the old subscription.
+`POST /api/v2/subscribeWebhook` (`{ targetUrl, triggerType }` -> `{ ok, hookId }`) and `POST /api/v2/unsubscribeWebhook` (`{ hookId }`) still work, but they are **deprecated**: each subscription covers a single event, scoping is account-level only, and deliveries are **not signed**. New integrations should use `POST /api/v2/webhooks`; existing ones can migrate by registering the same target URL with the new endpoint and removing the old subscription.
 
 ***
 

--- a/genesis-living-system-builder/ai-features/ai-agents-getting-started.md
+++ b/genesis-living-system-builder/ai-features/ai-agents-getting-started.md
@@ -336,16 +336,16 @@ Give your agent specific skills with custom commands:
 
 ## **Enhanced File Attachments**
 
-TAA (Taskade AI Assistant) conversations now support rich file interactions with complete visibility and context.
+Taskade EVE conversations now support rich file interactions with complete visibility and context.
 
 ### **Drag & Drop File Magic**
 
-Simply drag any file directly into your TAA chat:
+Simply drag any file directly into your EVE chat:
 
-* **Images**: JPG, PNG, GIF, WebP - TAA analyzes visual content
-* **Documents**: PDF, DOC, TXT - TAA reads and processes text
-* **Spreadsheets**: CSV, Excel - TAA analyzes data and creates insights
-* **Code Files**: Python, JavaScript, etc. - TAA reviews and suggests improvements
+* **Images**: JPG, PNG, GIF, WebP - EVE analyzes visual content
+* **Documents**: PDF, DOC, TXT - EVE reads and processes text
+* **Spreadsheets**: CSV, Excel - EVE analyzes data and creates insights
+* **Code Files**: Python, JavaScript, etc. - EVE reviews and suggests improvements
 
 ### **Visible File Context**
 
@@ -362,35 +362,35 @@ Files now appear directly alongside your messages instead of being hidden:
 
 ```
 You: [Attach quarterly_report.pdf] "Summarize the key findings and create action items"
-TAA: "I've analyzed your Q3 report. Here are the 5 key findings..."
+EVE: "I've analyzed your Q3 report. Here are the 5 key findings..."
 ```
 
 **Image Processing:**
 
 ```
 You: [Attach screenshot.png] "What's wrong with this UI design?"
-TAA: "Looking at your interface, I notice 3 usability issues..."
+EVE: "Looking at your interface, I notice 3 usability issues..."
 ```
 
 **Data Insights:**
 
 ```
 You: [Attach sales_data.csv] "What trends do you see in this data?"
-TAA: "Analyzing your sales data, I found these patterns..."
+EVE: "Analyzing your sales data, I found these patterns..."
 ```
 
 **Code Review:**
 
 ```
 You: [Attach app.py] "Review this code for security issues"
-TAA: "I've reviewed your Python code. Here are potential security concerns..."
+EVE: "I've reviewed your Python code. Here are potential security concerns..."
 ```
 
 ### **File Management Features**
 
-* **Rename Conversations**: Turn "Chat with TAA" into "Q3 Report Analysis"
+* **Rename Conversations**: Turn "Chat with EVE" into "Q3 Report Analysis"
 * **File History**: Access previously shared files from conversation history
-* **Cross-Reference**: TAA remembers files from earlier in the conversation
+* **Cross-Reference**: EVE remembers files from earlier in the conversation
 * **Batch Processing**: Upload multiple related files for comprehensive analysis
 
 ## Advanced Features

--- a/genesis-living-system-builder/ai-features/tsk-1-model-tiers.md
+++ b/genesis-living-system-builder/ai-features/tsk-1-model-tiers.md
@@ -27,7 +27,7 @@ TSK-1 sits between the **EVE** persona and **Workspace DNA** — it is the engin
 
 The model picker shows one TSK-1 header with a capability ladder. Each tier is defined by what it's good for, not by its underlying provider:
 
-| Tier | Best for | Example use | Selectable on |
+| Tier | Best for | Example use | Plans |
 |------|----------|------------|--------------|
 | **Instant** | Fast edits, simple completions, quick lookups | Rename a task, fix a typo, categorize an item | All plans |
 | **Standard** | Everyday work — balanced speed and reasoning | Draft an email, summarize a document, answer a question | Paid plans |

--- a/genesis-living-system-builder/space-apps-guide/advanced-features.md
+++ b/genesis-living-system-builder/space-apps-guide/advanced-features.md
@@ -180,19 +180,19 @@ Create specialized commands for specific business tasks:
 
 ### AI-Powered Agent Creation
 
-**TAA Creates Agents for You:**
+**EVE Creates Agents for You:**
 
-Your Taskade AI Assistant (TAA) can now build custom AI agents automatically based on your needs:
+Taskade EVE can now build custom AI agents automatically based on your needs:
 
 ```
-"TAA, create a marketing assistant agent that helps with content planning"
+"Create a marketing assistant agent that helps with content planning"
 "Set up a customer service bot for handling FAQ questions"  
 "Build a sales agent that qualifies leads from our contact form"
 ```
 
 **Automatic Configuration:**
 
-* TAA determines the optimal agent personality and tone
+* EVE determines the optimal agent personality and tone
 * Automatically selects appropriate AI models (GPT-4.1, Claude-4, etc.)
 * Configures relevant tools and integrations
 * Sets up proper knowledge sources and training
@@ -277,7 +277,7 @@ Connect your app to your existing business tools and create sophisticated workfl
 
 ### Enterprise-Grade Integrations
 
-Genesis apps can connect to **100+ business tools** through the TAA unified system:
+Genesis apps can connect to **100+ business tools** through Taskade's unified integration system:
 
 #### Communication & Collaboration
 

--- a/genesis-living-system-builder/workspaces/project-views.md
+++ b/genesis-living-system-builder/workspaces/project-views.md
@@ -31,7 +31,7 @@ All views are backed by the **same underlying data** — update a task in one vi
 
 > 💡 **Tip:** Use the `/view` slash-command or the View switcher in the top-right corner of any project to toggle between visualizations.
 
-> 📤 **Export any view.** The project's **⋯ More menu → Export** works in every view — including Mind Map, Board, Calendar, and Org Chart — on all plans. CSV export flattens the task tree (depth, text, note, completed) for spreadsheets and BI tools; Markdown export preserves the outline.
+> 📤 **Export any view.** The project's **⋯ More menu > Export** works in every view — including Mind Map, Board, Calendar, and Org Chart — on all plans. CSV export flattens the task tree (depth, text, note, completed) for spreadsheets and BI tools; Markdown export preserves the outline.
 
 ## When to Use Each View
 

--- a/updates-and-timeline/changelog-2026/july-2026/july-13-2026.md
+++ b/updates-and-timeline/changelog-2026/july-2026/july-13-2026.md
@@ -25,4 +25,4 @@ Form-trigger automation flows gain a **Checkbox** (boolean) field type. Add it i
 
 ### Self-Serve Custom Domain Reassignment
 
-You can now move a custom domain from one Space App to another yourself — no support ticket needed. Open **Edit Space → Domains**, pick the domain, and choose a destination workspace; the picker lists workspaces where you have permission to manage custom domains. Works for both Taskade-managed domains and domains you brought yourself. See [Put Your App on Your Own Domain](../../../genesis-living-system-builder/space-apps-guide/custom-domains.md).
+You can now move a custom domain from one Space App to another yourself — no support ticket needed. Open **Edit Space > Domains**, pick the domain, and choose a destination workspace; the picker lists workspaces where you have permission to manage custom domains. Works for both Taskade-managed domains and domains you brought yourself. See [Put Your App on Your Own Domain](../../../genesis-living-system-builder/space-apps-guide/custom-domains.md).

--- a/updates-and-timeline/changelog-2026/june-2026/june-3-2026.md
+++ b/updates-and-timeline/changelog-2026/june-2026/june-3-2026.md
@@ -23,9 +23,9 @@ Qwen 3.7 Plus is now available as a model option for agents and automations.
 
 ***
 
-### TAA UI Reskin
+### AI Agents UI Reskin
 
-The Taskade AI Agents (TAA) interface has been refreshed with an updated visual design — cleaner layouts, improved contrast, and a more consistent look across the agent management screens.
+The AI agents interface has been refreshed with an updated visual design — cleaner layouts, improved contrast, and a more consistent look across the agent management screens.
 
 ***
 

--- a/updates-and-timeline/changelog-2026/march-2026/march-22-2026.md
+++ b/updates-and-timeline/changelog-2026/march-2026/march-22-2026.md
@@ -21,7 +21,7 @@ Reference: [Workspace MCP](../../../apis-living-system-development/workspace-mcp
 
 ### Agent Memory Available Across All LLM Models
 
-The Genesis app builder agent (TAA) now persists memory for all configured LLM models, not only Anthropic models. The agent reads and writes memory entries autonomously across conversations. This is relevant for Genesis apps that rely on long-running or multi-session agent interactions, regardless of the model selected in the app configuration.
+Taskade EVE, the Genesis builder agent, now persists memory across all configured models. The agent reads and writes memory entries autonomously across conversations. This is relevant for Genesis apps that rely on long-running or multi-session agent interactions, regardless of the model selected in the app configuration.
 
 Reference: [Getting Started with Genesis](../../../genesis-living-system-builder/genesis/getting-started.md)
 

--- a/updates-and-timeline/changelog-2026/may-2026/may-12-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-12-2026.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Taskade developer changelog — May 12, 2026: Async Bundle Import/Export for Large Apps, TAA Can Enable MCP Tools During Genesis Generation.
+  Taskade developer changelog — May 12, 2026: Async Bundle Import/Export for Large Apps, EVE Can Enable MCP Tools During Genesis Generation.
 ---
 
 # May 12, 2026
@@ -15,6 +15,6 @@ description: >-
 
 App bundles can now be imported and exported asynchronously. For large Genesis apps with many components, this prevents request timeouts and gives you a progress indicator rather than a blocking operation. Programmatic bundle install is documented in [Bundles & App Kits](../../../apis-living-system-development/bundles.md).
 
-### TAA Can Enable MCP Tools During Genesis Generation
+### EVE Can Enable MCP Tools During Genesis Generation
 
-Taskade AI (TAA) can now activate MCP tools on the fly while generating a Genesis app via bash commands. This allows the generation process to pull in external data and capabilities without manual tool-enabling steps between generation phases. [Workspace MCP](../../../apis-living-system-development/workspace-mcp.md).
+Taskade EVE can now activate MCP tools on the fly while generating a Genesis app. This allows the generation process to pull in external data and capabilities without manual tool-enabling steps between generation phases. [Workspace MCP](../../../apis-living-system-development/workspace-mcp.md).

--- a/updates-and-timeline/changelog-2026/may-2026/may-5-2026.md
+++ b/updates-and-timeline/changelog-2026/may-2026/may-5-2026.md
@@ -23,6 +23,6 @@ Several frontier models are now available for use in agents and automations, inc
 
 AppSumo lifetime-deal holders can now bring their own LLM API keys, extending the BYOK capability previously available on Enterprise to this plan tier.
 
-### TAA Can Enable and Disable Automation Workflows
+### Taskade EVE Can Enable and Disable Automation Workflows
 
-Taskade AI (TAA) can now toggle automation workflows on or off during a session, allowing agents to dynamically manage which automations are active as part of a broader task sequence.
+Taskade EVE can now toggle automation workflows on or off during a session, allowing agents to dynamically manage which automations are active as part of a broader task sequence.


### PR DESCRIPTION
Follow-up polish from the post-merge live visual QA of #102 (Playwright sweep of docs.taskade.com — desktop + mobile, zero regressions found; these are the surviving nits):

- **Taskade EVE naming standardized** across guides and historical changelog entries (single consistent assistant name, abbreviations dropped).
- **TSK-1 tier table** header shortened to "Plans" so all four columns fit at 390px without swiping.
- **ASCII separators in nav paths** (Settings > API, Edit Space > Domains, More menu > Export) — the "→" glyph renders as blank space under the site font's fallback chain (missing U+2192 subset), so nav paths now use glyph-safe characters.
- **mcp-overview**: short link label for the settings URL to stop mid-word wrapping in the decision table.
- **Two short-slug redirects** added (tsk-1-model-tiers, genesis-app-mcp) for guessable URLs.

QA: YAML validated (no duplicate keys), all links resolve, GitBook syntax balanced.